### PR TITLE
Add udp transport

### DIFF
--- a/src/packet/decode.ts
+++ b/src/packet/decode.ts
@@ -23,6 +23,8 @@ import {
 /**
  * Decode raw bytes into a packet. The `magic` value (SHA2256(node-id, b"WHOAREYOU")) is passed as a parameter to check
  * for the magic byte sequence.
+ *
+ * Note: this function will modify the input data
  */
 export function decode(data: Buffer, magic: Magic): [PacketType, Packet] {
   if (data.length > MAX_PACKET_SIZE) {

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./udp";

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -1,0 +1,22 @@
+import {
+  Packet,
+  PacketType,
+} from "../packet";
+
+export interface ISocketAddr {
+  port: number;
+  address: string;
+}
+
+export interface IRemoteInfo {
+  address: string;
+  family: "IPv4" | "IPv6";
+  port: number;
+  size: number;
+}
+
+export interface ITransportService {
+  start(): Promise<void>;
+  close(): Promise<void>;
+  send(to: ISocketAddr, type: PacketType, packet: Packet): Promise<void>;
+}

--- a/src/transport/udp.ts
+++ b/src/transport/udp.ts
@@ -1,0 +1,64 @@
+import * as dgram from "dgram";
+import { EventEmitter } from "events";
+
+import {
+  decode,
+  encode,
+  Packet,
+  PacketType,
+  MAX_PACKET_SIZE,
+} from "../packet";
+import {
+  ISocketAddr,
+  IRemoteInfo,
+  ITransportService,
+} from "./types";
+
+
+/**
+ * This class is responsible for encoding outgoing Packets and decoding incoming Packets over UDP
+ */
+export class UDPTransportService extends EventEmitter implements ITransportService {
+
+  private socketAddr: ISocketAddr;
+  private socket: dgram.Socket;
+  private whoAreYouMagic: Buffer;
+
+  public constructor(socketAddr: ISocketAddr, whoAreYouMagic: Buffer) {
+    super();
+    this.socketAddr = socketAddr;
+    this.whoAreYouMagic = whoAreYouMagic;
+    this.socket = dgram.createSocket({
+      recvBufferSize: MAX_PACKET_SIZE,
+      sendBufferSize: MAX_PACKET_SIZE,
+      type: "udp4",
+    });
+  }
+
+  public async start(): Promise<void> {
+    this.socket.on("message", this.handleIncoming);
+    return new Promise((resolve) => this.socket.bind(this.socketAddr.port, resolve));
+  }
+
+  public async close(): Promise<void> {
+    this.socket.off("message", this.handleIncoming);
+    return new Promise((resolve) => this.socket.close(resolve));
+  }
+
+  public async send(to: ISocketAddr, type: PacketType, packet: Packet): Promise<void> {
+    return new Promise((resolve) => this.socket.send(encode(type, packet), to.port, to.address, () => resolve()));
+  }
+
+  public handleIncoming = (data: Buffer, rinfo: IRemoteInfo): void => {
+    const sender = {
+      address: rinfo.address,
+      port: rinfo.port,
+    };
+    try {
+      const [type, packet] = decode(data, this.whoAreYouMagic);
+      this.emit("packet", sender, type, packet);
+    } catch (e) {
+      this.emit("error", e, sender);
+    }
+  };
+}

--- a/test/transport/udp.test.ts
+++ b/test/transport/udp.test.ts
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+import {PacketType, TAG_LENGTH, AUTH_TAG_LENGTH, MAGIC_LENGTH} from "../../src/packet";
+import {UDPTransportService} from "../../src/transport";
+import { expect } from "chai";
+
+describe("UDP transport", () => {
+  const address = "127.0.0.1";
+  const magicA = Buffer.alloc(MAGIC_LENGTH, 1);
+  const portA = 49523;
+  const a = new UDPTransportService({port: portA, address}, magicA);
+
+  const magicB = Buffer.alloc(MAGIC_LENGTH, 2);
+  const portB = portA + 1;
+  const b = new UDPTransportService({port: portB, address}, magicB);
+
+  before(async () => {
+    await a.start();
+    await b.start();
+  });
+
+  after(async () => {
+    await a.close();
+    await b.close();
+  });
+
+  it("should send and receive messages", async () => {
+    const messagePacket = {
+      tag: Buffer.alloc(TAG_LENGTH),
+      authTag: Buffer.alloc(AUTH_TAG_LENGTH),
+      message: Buffer.alloc(44, 1),
+    };
+    const received = new Promise((resolve) =>
+      a.once("packet", (sender, type, packet) =>
+        resolve([sender, type, packet])));
+    await b.send(
+      {port: portA, address},
+      PacketType.Message,
+      messagePacket,
+    );
+    // @ts-ignore
+    const [rSender, rType, rPacket] = await received;
+    expect(rSender).to.deep.equal({port: portB, address});
+    expect(rType).to.equal(PacketType.Message);
+    expect(rPacket).to.deep.equal(messagePacket);
+  });
+});


### PR DESCRIPTION
Depends on #36 
Add a UDP transport that receives/decodes UDP packets into (sender, `PacketType`, `Packet`)
and encodes/sends (recipient, `PacketType`, `Packet`) via UDP.