### PR TITLE
Refactor ENR as a class

### DIFF
--- a/src/enr/enr.ts
+++ b/src/enr/enr.ts
@@ -5,64 +5,84 @@ import * as RLP from "rlp";
 
 import { MAX_RECORD_SIZE } from "./constants";
 import * as v4 from "./v4";
-import { ENR, ENRKey, ENRValue, PrivateKey, SequenceNumber } from "./types";
+import { ENRKey, ENRValue, SequenceNumber } from "./types";
 
-export function createENR(privateKey: PrivateKey, id = "v4"): ENR {
-  const record = new Map();
-  record.set("id", Buffer.from(id));
-  switch (id) {
-    case "v4":
-      record.set("secp256k1", v4.publicKey(privateKey));
-      break;
-    default:
-      assert.fail("invalid id");
+export class ENR extends Map<ENRKey, ENRValue> {
+  public seq: SequenceNumber;
+  constructor(kvs: Record<ENRKey, ENRValue> = {}, seq: SequenceNumber = 0n) {
+    super(Object.entries(kvs));
+    this.seq = seq;
   }
-  return record;
-}
-
-export function decode(encoded: Buffer): [ENR, SequenceNumber] {
-  const record = new Map();
-  const decoded = RLP.decode(encoded) as unknown as Buffer[];
-  assert(Array.isArray(decoded), "Decoded ENR must be an array");
-  assert(decoded.length % 2 === 0, "Decoded ENR must have an even number of elements");
-  const [signature, seq, ...kvs] = decoded;
-  for (let i = 0; i < kvs.length; i += 2) {
-    record.set(kvs[i].toString(), Buffer.from(kvs[i + 1]));
+  static createV4(publicKey: Buffer, kvs: Record<ENRKey, ENRValue> = {}): ENR {
+    return new ENR({
+      ...kvs,
+      "id": Buffer.from("v4"),
+      "secp256k1": publicKey,
+    });
   }
-  switch (record.get("id").toString("utf8")) {
-    case "v4":
-      assert(v4.verify(record.get("secp256k1"), RLP.encode([seq, ...kvs]), signature));
-      break;
-    default:
-      assert.fail("invalid record id");
+  static decode(encoded: Buffer): ENR {
+    const decoded = RLP.decode(encoded) as unknown as Buffer[];
+    assert(Array.isArray(decoded), "Decoded ENR must be an array");
+    assert(decoded.length % 2 === 0, "Decoded ENR must have an even number of elements");
+    const [signature, seq, ...kvs] = decoded;
+    const obj: Record<ENRKey, ENRValue> = {};
+    for (let i = 0; i < kvs.length; i += 2) {
+      obj[kvs[i].toString()] = Buffer.from(kvs[i + 1]);
+    }
+    const enr = new ENR(obj, toBigIntBE(seq));
+    assert(
+      enr.verify(RLP.encode([seq, ...kvs]), signature),
+      "Unable to verify enr signature"
+    );
+    return enr;
   }
-  return [record, toBigIntBE(seq)];
-}
-
-export function decodeTxt(encoded: string): [ENR, SequenceNumber] {
-  assert(encoded.startsWith("enr:"), "string encoded ENR must start with 'enr:'");
-  return decode(base64url.toBuffer(encoded.slice(4)));
-}
-
-export function encode(record: ENR, privateKey: PrivateKey, seq: SequenceNumber): Buffer {
-  // sort keys and flatten into [k, v, k, v, ...]
-  const content: Array<ENRKey | ENRValue> = Array.from(record.keys())
-    .sort((a, b) => a.localeCompare(b))
-    .map((k) => ([k, record.get(k)] as [ENRKey, ENRValue]))
-    .flat();
-  content.unshift(Number(seq));
-  switch ((record.get("id") as Buffer).toString("utf8")) {
-    case "v4":
-      content.unshift(v4.sign(privateKey, RLP.encode(content)));
-      break;
-    default:
-      assert.fail("invalid record id");
+  static decodeTxt(encoded: string): ENR {
+    assert(encoded.startsWith("enr:"), "string encoded ENR must start with 'enr:'");
+    return ENR.decode(base64url.toBuffer(encoded.slice(4)));
   }
-  const encoded = RLP.encode(content);
-  assert(encoded.length < MAX_RECORD_SIZE, "ENR must be less than 300 bytes");
-  return encoded;
-}
-
-export function encodeTxt(record: ENR, privateKey: PrivateKey, seq: SequenceNumber): string {
-  return "enr:" + base64url.encode(Buffer.from(encode(record, privateKey, seq)));
+  set(k: ENRKey, v: ENRValue): this {
+    this.seq++;
+    return super.set(k, v);
+  }
+  get id(): string {
+    return (this.get("id") as Buffer).toString("utf8");
+  }
+  // eslint-disable-next-line getter-return
+  get publicKey(): Buffer {
+    switch (this.id) {
+      case "v4":
+        return this.get("secp256k1") as Buffer;
+      default:
+        assert.fail("invalid record id");
+    }
+  }
+  verify(data: Buffer, signature: Buffer): boolean {
+    switch (this.id) {
+      case "v4":
+        return v4.verify(this.publicKey, data, signature);
+      default:
+        return false;
+    }
+  }
+  encode(privateKey: Buffer): Buffer {
+    // sort keys and flatten into [k, v, k, v, ...]
+    const content: Array<ENRKey | ENRValue> = Array.from(this.keys())
+      .sort((a, b) => a.localeCompare(b))
+      .map((k) => ([k, this.get(k)] as [ENRKey, ENRValue]))
+      .flat();
+    content.unshift(Number(this.seq));
+    switch (this.id) {
+      case "v4":
+        content.unshift(v4.sign(privateKey, RLP.encode(content)));
+        break;
+      default:
+        assert.fail("invalid record id");
+    }
+    const encoded = RLP.encode(content);
+    assert(encoded.length < MAX_RECORD_SIZE, "ENR must be less than 300 bytes");
+    return encoded;
+  }
+  encodeTxt(privateKey: Buffer): string {
+    return "enr:" + base64url.encode(Buffer.from(this.encode(privateKey)));
+  }
 }

--- a/src/enr/types.ts
+++ b/src/enr/types.ts
@@ -1,11 +1,7 @@
 // Custom and aliased types for ENRs
 
 export type NodeId = Buffer;
-export type PrivateKey = Buffer;
-export type PublicKey = Buffer;
-export type Signature = Buffer;
 export type SequenceNumber = bigint;
 
 export type ENRKey = string;
 export type ENRValue = number | string | Buffer;
-export type ENR = Map<ENRKey, ENRValue>;

--- a/src/enr/v4.ts
+++ b/src/enr/v4.ts
@@ -4,43 +4,41 @@ import secp256k1 = require("bcrypto/lib/secp256k1");
 
 import {
   NodeId,
-  PrivateKey,
-  PublicKey,
 } from "./types";
 
 export function hash(input: Buffer): Buffer {
   return keccak.digest(input);
 }
 
-export function createPrivateKey(): PrivateKey {
+export function createPrivateKey(): Buffer {
   return secp256k1.privateKeyGenerate();
 }
 
-export function publicKey(privKey: PrivateKey): PublicKey {
+export function publicKey(privKey: Buffer): Buffer {
   return secp256k1.publicKeyCreate(privKey);
 }
 
-export function sign(privKey: PrivateKey, msg: Buffer): Buffer {
+export function sign(privKey: Buffer, msg: Buffer): Buffer {
   return secp256k1.sign(
     hash(msg),
     privKey,
   );
 }
 
-export function verify(pubKey: PublicKey, msg: Buffer, sig: Buffer): boolean {
+export function verify(pubKey: Buffer, msg: Buffer, sig: Buffer): boolean {
   return secp256k1.verify(hash(msg), sig, pubKey);
 }
 
-export function nodeId(pubKey: PublicKey): NodeId {
+export function nodeId(pubKey: Buffer): NodeId {
   return hash(secp256k1.publicKeyConvert(pubKey, false));
 }
 
 export class ENRKeyPair {
   public readonly nodeId: NodeId;
-  public readonly privateKey: PrivateKey;
-  public readonly publicKey: PublicKey;
+  public readonly privateKey: Buffer;
+  public readonly publicKey: Buffer;
 
-  public constructor(privateKey?: PrivateKey) {
+  public constructor(privateKey?: Buffer) {
     if (privateKey) {
       assert(secp256k1.privateKeyVerify(privateKey));
     }

--- a/test/enr.test.ts
+++ b/test/enr.test.ts
@@ -1,35 +1,28 @@
 import { expect } from "chai";
-import { createENR, decode, decodeTxt, encode, encodeTxt } from "../src/enr/enr";
-import { ENR, PrivateKey } from "../src/enr/types";
+import { ENR, v4 } from "../src/enr";
 
 describe("ENR", () => {
   let seq: bigint;
-  let privateKey: PrivateKey;
+  let privateKey: Buffer;
   let record: ENR;
 
   beforeEach(() => {
     seq = 1n;
     privateKey = Buffer.from("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291", "hex");
-    record = createENR(privateKey);
+    record = ENR.createV4(v4.publicKey(privateKey));
     record.set("ip", Buffer.from("7f000001", "hex"));
     record.set("udp", Buffer.from((30303).toString(16), "hex"));
+    record.seq = seq;
   });
 
   it("should encode/decode to RLP encoding", () => {
-    const [decoded, seq2] = decode(encode(record, privateKey, seq));
-    expect(seq2).to.equal(seq);
-    for (const [k, v] of decoded.entries()) {
-      expect(v).to.deep.equal(record.get(k));
-    }
+    const decoded = ENR.decode(record.encode(privateKey));
+    expect(decoded).to.deep.equal(record);
   });
-
   it("should encode/decode to text encoding", () => {
     const testTxt = "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
-    const [testRecord, seq2] = decodeTxt(testTxt);
-    expect(seq2).to.equal(seq);
-    for (const [k, v] of testRecord.entries()) {
-      expect(v).to.deep.equal(record.get(k));
-    }
-    expect(encodeTxt(record, privateKey, seq)).to.equal(testTxt);
+    const decoded = ENR.decodeTxt(testTxt);
+    expect(decoded).to.deep.equal(record);
+    expect(record.encodeTxt(privateKey)).to.equal(testTxt);
   });
 });


### PR DESCRIPTION
`ENR` is now a class the extends `Map`.
This allows us to maintain a sequence number that gets incremented on every `set`.
It also simplifies/standardizes accessing the `record.id`, `record.publicKey`, and `record.seq`.

The aliases `PublicKey`, `PrivateKey`, and `Signature` are also removed in favor of using `Buffer` directly.