### PR TITLE
Add signature to enr

### DIFF
--- a/src/enr/constants.ts
+++ b/src/enr/constants.ts
@@ -1,2 +1,6 @@
 // Maximum encoded size of an ENR
 export const MAX_RECORD_SIZE = 300;
+
+export const ERR_INVALID_ID = "Invalid record id";
+
+export const ERR_NO_SIGNATURE = "No valid signature found";

--- a/src/enr/enr.ts
+++ b/src/enr/enr.ts
@@ -78,7 +78,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
   sign(data: Buffer, privateKey: Buffer): Buffer {
     switch (this.id) {
       case "v4":
-        this.signature = v4.sign(privateKey, RLP.encode(data));
+        this.signature = v4.sign(privateKey, data);
         break;
       default:
         throw new Error(ERR_INVALID_ID);

--- a/src/enr/types.ts
+++ b/src/enr/types.ts
@@ -4,4 +4,4 @@ export type NodeId = Buffer;
 export type SequenceNumber = bigint;
 
 export type ENRKey = string;
-export type ENRValue = number | string | Buffer;
+export type ENRValue = Buffer;


### PR DESCRIPTION
Add signature to enr - caches signature in enr, wipes if it is modified. This allows us to encode a previously-decoded enr without the private key.
Add nodeId getter