### PR TITLE
More complete session logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dgram": "^1.0.1",
     "ip": "^1.1.5",
     "rlp": "^2.2.4",
+    "strict-event-emitter-types": "^2.0.0",
     "typescript-collections": "^1.3.3"
   }
 }

--- a/src/enr/index.ts
+++ b/src/enr/index.ts
@@ -3,4 +3,5 @@ export const v4 = v4Crypto;
 export * from "./constants";
 export * from "./enr";
 export * from "./types";
+export * from "./util";
 

--- a/src/enr/types.ts
+++ b/src/enr/types.ts
@@ -1,6 +1,7 @@
 // Custom and aliased types for ENRs
 
 export type NodeId = Buffer;
+export type NodeIdHex = string;
 export type SequenceNumber = bigint;
 
 export type ENRKey = string;

--- a/src/enr/util.ts
+++ b/src/enr/util.ts
@@ -32,7 +32,6 @@ export function setUDPSocketAddr(enr: ENR, udpSocketAddr: ISocketAddr): void {
 // calculate node id / tag
 
 export function getSrcId(enr: ENR, tag: Tag): NodeId {
-  const nodeId = enr.nodeId;
   const hash = sha256.digest(enr.nodeId);
   // reuse `hash` buffer for output
   for (let i = 0; i < 32; i++) {

--- a/src/enr/util.ts
+++ b/src/enr/util.ts
@@ -1,0 +1,52 @@
+import * as ip from "ip";
+import sha256 = require("bcrypto/lib/sha256");
+
+import { ISocketAddr } from "../transport";
+import { ENR, NodeId } from "../enr";
+import { Tag } from "../packet";
+
+// get/set socket addrs
+
+export function getUDPSocketAddr(enr: ENR): ISocketAddr {
+  const rawIp = enr.get("ip");
+  if (!rawIp) {
+    throw new Error("ENR does not contain an \"ip\" field.");
+  }
+  const rawUdp = enr.get("udp");
+  if (!rawUdp) {
+    throw new Error("ENR does not contain an \"udp\" field.");
+  }
+  return {
+    address: ip.toString(rawIp),
+    port: rawUdp.readInt16BE(0),
+  };
+}
+
+export function setUDPSocketAddr(enr: ENR, udpSocketAddr: ISocketAddr): void {
+  enr.set("ip", ip.toBuffer(udpSocketAddr.address));
+  const rawPort = Buffer.alloc(2);
+  rawPort.writeUInt16BE(udpSocketAddr.port, 0);
+  enr.set("port", rawPort);
+}
+
+// calculate node id / tag
+
+export function getSrcId(enr: ENR, tag: Tag): NodeId {
+  const nodeId = enr.nodeId;
+  const hash = sha256.digest(enr.nodeId);
+  // reuse `hash` buffer for output
+  for (let i = 0; i < 32; i++) {
+    hash[i] = hash[i] ^ tag[i];
+  }
+  return hash;
+}
+
+export function getTag(enr: ENR, dstId: NodeId): Tag {
+  const nodeId = enr.nodeId;
+  const hash = sha256.digest(dstId);
+  // reuse `hash` buffer for output
+  for (let i = 0; i < 32; i++) {
+    hash[i] = hash[i] ^ nodeId[i];
+  }
+  return hash;
+}

--- a/src/message/decode.ts
+++ b/src/message/decode.ts
@@ -17,25 +17,25 @@ import { ENR } from "../enr";
 
 const ERR_INVALID_MESSAGE = "invalid message";
 
-export function decode(data: Buffer): [MessageType, Message] {
+export function decode(data: Buffer): Message {
   const type = data[0];
   switch (type) {
     case MessageType.PING:
-      return [MessageType.PING, decodePing(data)];
+      return decodePing(data);
     case MessageType.PONG:
-      return [MessageType.PONG, decodePong(data)];
+      return decodePong(data);
     case MessageType.FINDNODE:
-      return [MessageType.FINDNODE, decodeFindNode(data)];
+      return decodeFindNode(data);
     case MessageType.NODES:
-      return [MessageType.NODES, decodeNodes(data)];
+      return decodeNodes(data);
     case MessageType.REGTOPIC:
-      return [MessageType.REGTOPIC, decodeRegTopic(data)];
+      return decodeRegTopic(data);
     case MessageType.TICKET:
-      return [MessageType.TICKET, decodeTicket(data)];
+      return decodeTicket(data);
     case MessageType.REGCONFIRMATION:
-      return [MessageType.REGCONFIRMATION, decodeRegConfirmation(data)];
+      return decodeRegConfirmation(data);
     case MessageType.TOPICQUERY:
-      return [MessageType.TOPICQUERY, decodeTopicQuery(data)];
+      return decodeTopicQuery(data);
     default:
       throw new Error(ERR_INVALID_MESSAGE);
   }
@@ -47,6 +47,7 @@ function decodePing(data: Buffer): IPingMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
+    type: MessageType.PING,
     id: toBigIntBE(rlpRaw[0]),
     enrSeq: toBigIntBE(rlpRaw[1]),
   };
@@ -58,6 +59,7 @@ function decodePong(data: Buffer): IPongMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
+    type: MessageType.PONG,
     id: toBigIntBE(rlpRaw[0]),
     enrSeq: toBigIntBE(rlpRaw[1]),
     recipientIp: ip.toString(rlpRaw[2]),
@@ -71,6 +73,7 @@ function decodeFindNode(data: Buffer): IFindNodeMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
+    type: MessageType.FINDNODE,
     id: toBigIntBE(rlpRaw[0]),
     distance: rlpRaw[1].readUIntBE(0, rlpRaw[1].length),
   };
@@ -84,6 +87,7 @@ function decodeNodes(data: Buffer): INodesMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
+    type: MessageType.NODES,
     id: toBigIntBE(rlpRaw[0]),
     total: rlpRaw[1].readUIntBE(0, rlpRaw[1].length),
     enrs: rlpRaw[2].map(enrRaw => ENR.decode(enrRaw)),
@@ -96,6 +100,7 @@ function decodeRegTopic(data: Buffer): IRegTopicMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
+    type: MessageType.REGTOPIC,
     id: toBigIntBE(rlpRaw[0]),
     topic: rlpRaw[1],
     enr: ENR.decode(rlpRaw[2]),
@@ -109,6 +114,7 @@ function decodeTicket(data: Buffer): ITicketMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
+    type: MessageType.TICKET,
     id: toBigIntBE(rlpRaw[0]),
     ticket: rlpRaw[1],
     waitTime: rlpRaw[2].readUIntBE(0, rlpRaw[2].length),
@@ -121,6 +127,7 @@ function decodeRegConfirmation(data: Buffer): IRegConfirmationMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
+    type: MessageType.REGCONFIRMATION,
     id: toBigIntBE(rlpRaw[0]),
     topic: rlpRaw[1],
   };
@@ -132,7 +139,8 @@ function decodeTopicQuery(data: Buffer): ITopicQueryMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
+    type: MessageType.TOPICQUERY,
     id: toBigIntBE(rlpRaw[0]),
     topic: rlpRaw[1],
-  };}
-
+  };
+}

--- a/src/message/encode.ts
+++ b/src/message/encode.ts
@@ -13,8 +13,8 @@ import {
   MessageType,
 } from "./types";
 
-export function encode(type: MessageType, message: Message): Buffer {
-  switch (type) {
+export function encode(message: Message): Buffer {
+  switch (message.type) {
     case MessageType.PING:
       return encodePingMessage(message as IPingMessage);
     case MessageType.PONG:

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -28,11 +28,13 @@ export type ResponseMessage =
   IRegConfirmationMessage;
 
 export interface IPingMessage {
+  type: MessageType.PING;
   id: RequestId;
   enrSeq: SequenceNumber;
 }
 
 export interface IPongMessage {
+  type: MessageType.PONG;
   id: RequestId;
   enrSeq: SequenceNumber;
   recipientIp: string;
@@ -40,17 +42,20 @@ export interface IPongMessage {
 }
 
 export interface IFindNodeMessage {
+  type: MessageType.FINDNODE;
   id: RequestId;
   distance: number;
 }
 
 export interface INodesMessage {
+  type: MessageType.NODES;
   id: RequestId;
   total: number;
   enrs: ENR[];
 }
 
 export interface IRegTopicMessage {
+  type: MessageType.REGTOPIC;
   id: RequestId;
   topic: Buffer;
   enr: ENR;
@@ -58,17 +63,20 @@ export interface IRegTopicMessage {
 }
 
 export interface ITicketMessage {
+  type: MessageType.TICKET;
   id: RequestId;
   ticket: Buffer;
   waitTime: number;
 }
 
 export interface IRegConfirmationMessage {
+  type: MessageType.REGCONFIRMATION;
   id: RequestId;
   topic: Buffer;
 }
 
 export interface ITopicQueryMessage {
+  type: MessageType.TOPICQUERY;
   id: RequestId;
   topic: Buffer;
 }

--- a/src/packet/create.ts
+++ b/src/packet/create.ts
@@ -2,11 +2,12 @@ import { randomBytes } from "bcrypto/lib/random";
 import sha256 = require("bcrypto/lib/sha256");
 
 import { AUTH_TAG_LENGTH, ID_NONCE_LENGTH, RANDOM_DATA_LENGTH, WHOAREYOU_STRING } from "./constants";
-import { IMessagePacket, Tag, AuthTag, IWhoAreYouPacket, IAuthResponse, Nonce, IAuthHeader } from "./types";
+import { IMessagePacket, Tag, AuthTag, IWhoAreYouPacket, IAuthResponse, Nonce, IAuthHeader, PacketType } from "./types";
 import { NodeId, SequenceNumber, ENR } from "../enr";
 
 export function createRandomPacket(tag: Tag): IMessagePacket {
   return {
+    type: PacketType.Message,
     tag,
     authTag: randomBytes(AUTH_TAG_LENGTH),
     message: randomBytes(RANDOM_DATA_LENGTH),
@@ -23,6 +24,7 @@ export function createWhoAreYouPacket(
   enrSeq: SequenceNumber
 ): IWhoAreYouPacket {
   return {
+    type: PacketType.WhoAreYou,
     magic: createMagic(nodeId),
     token: authTag,
     idNonce: randomBytes(ID_NONCE_LENGTH),

--- a/src/packet/create.ts
+++ b/src/packet/create.ts
@@ -2,12 +2,12 @@ import { randomBytes } from "bcrypto/lib/random";
 import sha256 = require("bcrypto/lib/sha256");
 
 import { AUTH_TAG_LENGTH, ID_NONCE_LENGTH, RANDOM_DATA_LENGTH, WHOAREYOU_STRING } from "./constants";
-import { IMessagePacket, Tag, AuthTag, IWhoAreYouPacket, IAuthResponse, Nonce, IAuthHeader, PacketType } from "./types";
+import { Tag, AuthTag, IWhoAreYouPacket, IAuthResponse, Nonce, IAuthHeader, PacketType, IRandomPacket } from "./types";
 import { NodeId, SequenceNumber, ENR } from "../enr";
 
-export function createRandomPacket(tag: Tag): IMessagePacket {
+export function createRandomPacket(tag: Tag): IRandomPacket {
   return {
-    type: PacketType.Message,
+    type: PacketType.Random,
     tag,
     authTag: randomBytes(AUTH_TAG_LENGTH),
     message: randomBytes(RANDOM_DATA_LENGTH),

--- a/src/packet/decode.ts
+++ b/src/packet/decode.ts
@@ -28,7 +28,7 @@ import {
  *
  * Note: this function will modify the input data
  */
-export function decode(data: Buffer, magic: Magic): [PacketType, Packet] {
+export function decode(data: Buffer, magic: Magic): Packet {
   if (data.length > MAX_PACKET_SIZE) {
     throw new Error(ERR_TOO_LARGE);
   }
@@ -44,20 +44,11 @@ export function decode(data: Buffer, magic: Magic): [PacketType, Packet] {
   //   tag   ++ rlp_bytes(...) ++ message
   //   tag   ++ rlp_list(...)  ++ message
   if (tag.equals(magic)) {
-    return [
-      PacketType.WhoAreYou,
-      decodeWhoAreYou(tag, decoded.data as Buffer[], decoded.remainder)
-    ];
+    return decodeWhoAreYou(tag, decoded.data as Buffer[], decoded.remainder);
   } else if (!Array.isArray(decoded.data)) {
-    return [
-      PacketType.Message,
-      decodeStandardMessage(tag, decoded.data, decoded.remainder),
-    ];
+    return decodeStandardMessage(tag, decoded.data, decoded.remainder);
   } else {
-    return [
-      PacketType.AuthMessage,
-      decodeAuthHeader(tag, decoded.data, decoded.remainder),
-    ];
+    return decodeAuthHeader(tag, decoded.data, decoded.remainder);
   }
 }
 
@@ -74,6 +65,7 @@ export function decodeWhoAreYou(magic: Magic, data: Buffer[], remainder: Buffer)
   }
   const enrSeq = Number(`0x${enrSeqBytes.toString("hex")}`);
   return {
+    type: PacketType.WhoAreYou,
     token,
     magic,
     idNonce,
@@ -83,6 +75,7 @@ export function decodeWhoAreYou(magic: Magic, data: Buffer[], remainder: Buffer)
 
 export function decodeStandardMessage(tag: Tag, data: Buffer, remainder: Buffer): IMessagePacket {
   return {
+    type: PacketType.Message,
     tag,
     authTag: data,
     message: remainder,
@@ -102,6 +95,7 @@ export function decodeAuthHeader(tag: Tag, data: Buffer[], remainder: Buffer): I
     authResponse,
   ] = data;
   return {
+    type: PacketType.AuthMessage,
     tag,
     authHeader: {
       authTag,

--- a/src/packet/encode.ts
+++ b/src/packet/encode.ts
@@ -15,6 +15,7 @@ export function encode(packet: Packet): Buffer {
       return encodeWhoAreYouPacket(packet as IWhoAreYouPacket);
     case PacketType.AuthMessage:
       return encodeAuthMessagePacket(packet as IAuthMessagePacket);
+    case PacketType.Random:
     case PacketType.Message:
       return encodeMessagePacket(packet as IMessagePacket);
   }

--- a/src/packet/encode.ts
+++ b/src/packet/encode.ts
@@ -9,8 +9,8 @@ import {
   IAuthResponse,
 } from "./types";
 
-export function encode(type: PacketType, packet: Packet): Buffer {
-  switch (type) {
+export function encode(packet: Packet): Buffer {
+  switch (packet.type) {
     case PacketType.WhoAreYou:
       return encodeWhoAreYouPacket(packet as IWhoAreYouPacket);
     case PacketType.AuthMessage:

--- a/src/packet/types.ts
+++ b/src/packet/types.ts
@@ -41,6 +41,7 @@ export interface IRegularPacket {
  */
 
 export interface IWhoAreYouPacket {
+  type: PacketType.WhoAreYou;
   // SHA256(`dest-node-id` || "WHOAREYOU").
   magic: Magic;
   // The auth-tag of the request.
@@ -52,6 +53,7 @@ export interface IWhoAreYouPacket {
 }
 
 export interface IAuthMessagePacket extends IRegularPacket {
+  type: PacketType.AuthMessage;
   // Authentication header.
   authHeader: IAuthHeader;
   // The encrypted message including the authentication header.
@@ -59,6 +61,7 @@ export interface IAuthMessagePacket extends IRegularPacket {
 }
 
 export interface IMessagePacket extends IRegularPacket {
+  type: PacketType.Message;
   // 12 byte Authentication nonce.
   authTag: AuthTag;
   // The encrypted message as raw bytes.

--- a/src/packet/types.ts
+++ b/src/packet/types.ts
@@ -11,9 +11,10 @@ export enum PacketType {
   WhoAreYou = 1,
   AuthMessage,
   Message,
+  Random,
 }
 
-export type Packet = IWhoAreYouPacket | IAuthMessagePacket | IMessagePacket;
+export type Packet = IWhoAreYouPacket | IAuthMessagePacket | IMessagePacket | IRandomPacket;
 
 export interface IAuthHeader {
   authTag: Buffer;
@@ -65,5 +66,13 @@ export interface IMessagePacket extends IRegularPacket {
   // 12 byte Authentication nonce.
   authTag: AuthTag;
   // The encrypted message as raw bytes.
+  message: Buffer;
+}
+
+export interface IRandomPacket extends IRegularPacket {
+  type: PacketType.Random;
+  // 12 byte Authentication nonce.
+  authTag: AuthTag;
+  // random data
   message: Buffer;
 }

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -82,6 +82,7 @@ export default class Service {
    *
    * @param enr the new peer to consider for discovery
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
   async addPeer(enr: ENR): Promise<void> {
   }
 
@@ -94,6 +95,7 @@ export default class Service {
       for (const bootstrapURL of this.bootstrapURLs) {
         try {
           const peerENR = ENR.decodeTxt(bootstrapURL);
+          this.addPeer(peerENR);
         } catch(e) {
           LOG.log("Ignoring invalid bootstrap ENR record %s: %s", bootstrapURL, e);
         }

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -1,9 +1,11 @@
-import {UDPTransportService} from "../transport";
-import {MAGIC_LENGTH} from "../packet";
-import {randomBytes} from "crypto";
-import {SessionService} from "../session/service";
-import {ENR} from "../enr";
+import { randomBytes } from "crypto";
 import debug from "debug";
+
+import { UDPTransportService } from "../transport";
+import { MAGIC_LENGTH } from "../packet";
+import { SessionService } from "../session";
+import { ENR } from "../enr";
+import { IKeypair } from "../keypair";
 
 const LOG = debug("discv5/service");
 
@@ -37,11 +39,13 @@ export default class Service {
    * @param bootstrapURLs the initial peers the discovery service should attempt to connect to. Each peer is an ENR URI.
    * @param sessionService the service managing sessions underneath.
    */
-  constructor(enr: ENR,
+  constructor(
+    enr: ENR,
     port = 30303,
     networkInterface = "0.0.0.0",
     bootstrapURLs: string[] = [],
-    sessionService: SessionService) {
+    sessionService: SessionService
+  ) {
 
     if (port < 1 || port > 65535) {
       throw `Invalid port number ${port}. It should be between 1 and 65535.`;
@@ -60,10 +64,16 @@ export default class Service {
    * @param networkInterface the network interface to which the UDP transport binds.
    * @param bootstrapURLs the initial peers the discovery service should attempt to connect to. Each peer is an ENR URI.
    */
-  static create(enr: ENR, port = 30303, networkInterface = "0.0.0.0", bootstrapURLs: string[] = []): Service {
+  static create(
+    enr: ENR,
+    keypair: IKeypair,
+    port = 30303,
+    networkInterface = "0.0.0.0",
+    bootstrapURLs: string[] = []
+  ): Service {
     const magic = randomBytes(MAGIC_LENGTH);
     const udpTransport = new UDPTransportService({port: port, address: networkInterface}, magic);
-    const sessionService = new SessionService(enr, udpTransport);
+    const sessionService = new SessionService(enr, keypair, udpTransport);
     return new Service(enr, port, networkInterface, bootstrapURLs, sessionService);
   }
 
@@ -73,7 +83,6 @@ export default class Service {
    * @param enr the new peer to consider for discovery
    */
   async addPeer(enr: ENR): Promise<void> {
-    await this.sessionService.addPeer(enr);
   }
 
   /**
@@ -85,7 +94,6 @@ export default class Service {
       for (const bootstrapURL of this.bootstrapURLs) {
         try {
           const peerENR = ENR.decodeTxt(bootstrapURL);
-          this.sessionService.addPeer(peerENR);
         } catch(e) {
           LOG.log("Ignoring invalid bootstrap ENR record %s: %s", bootstrapURL, e);
         }
@@ -103,6 +111,4 @@ export default class Service {
       this.started = false;
     }
   }
-
-
 }

--- a/src/session/constants.ts
+++ b/src/session/constants.ts
@@ -1,0 +1,10 @@
+// 4 sec
+export const REQUEST_TIMEOUT = 4000;
+
+export const REQUEST_RETRIES = 1;
+
+// 24 hrs
+export const SESSION_TIMEOUT = 86400 * 1000;
+
+// 15 sec
+export const SESSION_ESTABLISH_TIMEOUT = 15000;

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,2 +1,4 @@
 export * from "./types";
 export * from "./crypto";
+export * from "./session";
+export * from "./service";

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -1,18 +1,16 @@
-import {EventEmitter} from "events";
-import {ISocketAddr, ITransportService} from "../transport";
-import {
-  createAuthTag,
-  IAuthMessagePacket,
-  IMessagePacket,
-  IWhoAreYouPacket,
-  Packet,
-  PacketType
-} from "../packet";
-import {ENR, NodeId} from "../enr";
-import {Session} from "./session";
-import {KademliaRoutingTable} from "../kademlia/kademlia";
+import { EventEmitter } from "events";
+import StrictEventEmitter from "strict-event-emitter-types";
 
-const ENTRIES_PER_BUCKET = 16;
+import { ITransportService, ISocketAddr } from "../transport";
+import { PacketType, Packet, IWhoAreYouPacket, IAuthMessagePacket, IMessagePacket, AuthTag } from "../packet";
+import { ENR, NodeIdHex, getUDPSocketAddr, getTag, NodeId, getSrcId } from "../enr";
+import { Session } from "./session";
+import { IKeypair } from "../keypair";
+import { TimeoutMap, toHex, fromHex } from "../util";
+import { Message, RequestMessage, encode, decode, ResponseMessage, RequestId } from "../message";
+import { IPendingRequest, SessionState, ISessionEvents } from "./types";
+import { SESSION_TIMEOUT, REQUEST_TIMEOUT, REQUEST_RETRIES } from "./constants";
+
 /**
  * Session management for the Discv5 Discovery service.
  *
@@ -30,17 +28,45 @@ const ENTRIES_PER_BUCKET = 16;
  * to match the source, the `Session` is promoted to an established state. RPC requests are not sent
  * to untrusted Sessions, only responses.
  */
-export class SessionService extends EventEmitter {
+export class SessionService extends (EventEmitter as { new(): StrictEventEmitter<EventEmitter, ISessionEvents> }) {
+  /**
+   * The local ENR
+   */
   private enr: ENR;
+  /**
+   * The keypair to sign the ENR and set up encrypted communication with peers
+   */
+  private keypair: IKeypair;
+  /**
+   * The underlying packet transport
+   */
   private transport: ITransportService;
-  private sessions: Map<NodeId, Session>;
-  private routingTable: KademliaRoutingTable<ENR>;
-  constructor(enr: ENR, transport: ITransportService) {
+  /**
+   * Pending raw requests
+   * A collection of request objects we are awaiting a response from the remote.
+   * These are indexed by ISocketAddr as WHOAREYOU packets do not return a source node id to
+   * match against.
+   * We need to keep pending requests for sessions not yet fully connected.
+   */
+  private pendingRequests: Map<ISocketAddr, TimeoutMap<RequestId, IPendingRequest>>;
+  /**
+   * Messages awaiting to be sent once a handshake has been established
+   */
+  private pendingMessages: Map<NodeIdHex, RequestMessage[]>;
+  /**
+   * Sessions that have been created for each node id. These can be established or
+   * awaiting response from remote nodes
+   */
+  private sessions: TimeoutMap<NodeIdHex, Session>;
+
+  constructor(enr: ENR, keypair: IKeypair, transport: ITransportService) {
     super();
     this.enr = enr;
+    this.keypair = keypair;
     this.transport = transport;
-    this.sessions = new Map();
-    this.routingTable = new KademliaRoutingTable<ENR>(enr.nodeId, ENTRIES_PER_BUCKET, (entry: ENR) => entry.nodeId);
+    this.pendingRequests = new Map();
+    this.pendingMessages = new Map();
+    this.sessions = new TimeoutMap(SESSION_TIMEOUT, this.onSessionTimeout);
   }
 
   /**
@@ -57,64 +83,428 @@ export class SessionService extends EventEmitter {
   public async close(): Promise<void> {
     this.transport.removeListener("packet", this.onPacket);
     await this.transport.close();
+    for (const requestMap of this.pendingRequests.values()) {
+      requestMap.clear();
+    }
+    this.pendingRequests.clear();
+    this.pendingMessages.clear();
+    this.sessions.clear();
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
   public onWhoAreYou(from: ISocketAddr, packet: IWhoAreYouPacket): void {
+    const pendingRequests = this.pendingRequests.get(from);
+    if (!pendingRequests) {
+      // Received a WHOAREYOU packet that references an unknown or expired request.
+      return;
+    }
+    const request = Array.from(pendingRequests.values()).find((r) =>
+      packet.token.equals((r.packet as IMessagePacket).authTag || Buffer.alloc(0)));
+    if (!request) {
+      // Received a WHOAREYOU packet that references an unknown or expired request.
+      return;
+    }
+    if (pendingRequests.size === 1) {
+      this.pendingRequests.delete(from);
+    } else {
+      pendingRequests.delete(request.message ? request.message.id : 0n);
+    }
 
+    // This is an assumed NodeId. We sent the packet to this NodeId and can only verify it against the
+    // originating IP address. We assume it comes from this NodeId.
+    const srcId = request.dstId;
+    const srcIdHex = toHex(srcId);
+    const tag = getTag(this.enr, srcId);
+
+    const session = this.sessions.get(srcIdHex);
+    if (!session) {
+      // Received a WhoAreYou packet without having an established session
+      return;
+    }
+
+    // Determine which message to send back. A WhoAreYou could refer to the random packet
+    // sent during establishing a connection, or their session has expired on one of our
+    // send messages and we need to re-encrypt it
+    let message: RequestMessage;
+    if (request.packet.type === PacketType.Random) {
+      // get the messages that are waiting for an established session
+      const messages = this.pendingMessages.get(srcIdHex);
+      if (!messages || !messages.length) {
+        throw new Error("No pending messages found for WHOAREYOU request.");
+      }
+      message = messages.shift() as RequestMessage;
+      this.pendingMessages.set(srcIdHex, messages);
+    } else {
+      if (!request.message) {
+        throw new Error("All non-random requests must have an unencrypted message");
+      }
+      // re-send the original message
+      message = request.message as RequestMessage;
+    }
+    // Update the session (this must be the socket that we sent the referenced request to)
+    session.lastSeenSocket = from;
+
+    // Update the ENR record if necessary
+    let updatedEnr: ENR | null = null;
+    if (packet.enrSeq < this.enr.seq) {
+      updatedEnr = this.enr;
+    }
+
+    // Generate session keys and encrypt the earliest packet with the authentication header
+    try {
+      const authPacket = session.encryptWithHeader(
+        tag,
+        this.keypair,
+        updatedEnr,
+        this.enr.nodeId,
+        packet.idNonce,
+        encode(message)
+      );
+
+      // send the response
+      this.processRequest(srcId, from, authPacket, message);
+
+      // flush the message cache
+      this.flushMessages(srcId, from);
+    } catch (e) {
+      // insert the message back into the pending queue
+      let messages = this.pendingMessages.get(srcIdHex);
+      if (!messages) {
+        messages = [];
+      }
+      messages.unshift(message);
+      this.pendingMessages.set(srcIdHex, messages);
+      throw new Error("Could not generate a session");
+    }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
   public onAuthMessage(from: ISocketAddr, packet: IAuthMessagePacket): void {
+    // Needs to match an outgoing WHOAREYOU packet (so we have the required nonce to be signed).
+    // If it doesn't we drop the packet.
+    // This will lead to future outgoing WHOAREYOU packets if they proceed to send further encrypted packets
+    const srcId = getSrcId(this.enr, packet.tag);
+    const srcIdHex = toHex(srcId);
+
+    const session = this.sessions.get(srcIdHex);
+    if (!session) {
+      throw new Error("Received an authenticated header without a known session");
+    }
+
+    if (session.state.state !== SessionState.WhoAreYouSent) {
+      throw new Error("Received an authenticated header without a known WHOAREYOU session");
+    }
+
+    const pendingRequests = this.pendingRequests.get(from);
+    if (!pendingRequests) {
+      throw new Error("Received an authenticated header without a matching WHOAREYOU request");
+    }
+    const request = Array.from(pendingRequests.values()).find((r) =>
+      r.packet.type === PacketType.WhoAreYou && r.dstId.equals(srcId));
+    if (!request) {
+      throw new Error("Received an authenticated header without a matching WHOAREYOU request");
+    }
+    if (pendingRequests.size === 1) {
+      this.pendingRequests.delete(from);
+    } else {
+      pendingRequests.delete(request.message ? request.message.id : 0n);
+    }
+
+    const idNonce = (request.packet as IWhoAreYouPacket).idNonce;
+
+    // update the sessions last seen socket
+    session.lastSeenSocket = from;
+
+    // establish the session
+    try {
+      const trusted = session.establishFromHeader(this.keypair, this.enr.nodeId, srcId, idNonce, packet.authHeader);
+      if (trusted) {
+        // session is trusted, notify the protocol
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.emit("established", session.remoteEnr!);
+        // flush messages
+        this.flushMessages(srcId, from);
+      }
+    } catch (e) {
+      this.sessions.delete(srcIdHex);
+      this.pendingMessages.delete(srcIdHex);
+      throw new Error("Invalid Authentication header. Dropping session.");
+    }
+
+    // session has been established, update the timeout
+    this.sessions.setTimeout(srcIdHex, SESSION_TIMEOUT);
+
+    // decrypt the message
+    this.onMessage(
+      from,
+      {
+        type: PacketType.Message,
+        authTag: packet.authHeader.authTag,
+        message: packet.message,
+        tag: packet.tag,
+      }
+    );
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
   public onMessage(from: ISocketAddr, packet: IMessagePacket): void {
+    const srcId = getSrcId(this.enr, packet.tag);
+    const srcIdHex = toHex(srcId);
+
+    // check if we have an available session
+    const session = this.sessions.get(srcIdHex);
+    if (!session) {
+      // Received a message without a session.
+
+      // spawn a WHOAREYOU event to check for highest known ENR
+      this.emit("whoAreYouRequest", srcId, from, packet.authTag);
+      throw new Error();
+    }
+    // if we have sent a random packet, upgrade to a WHOAREYOU request
+    if (session.state.state === SessionState.RandomSent) {
+      this.emit("whoAreYouRequest", srcId, from, packet.authTag);
+    } else if (session.state.state === SessionState.WhoAreYouSent) {
+      // Waiting for a session to be generated
+
+      // potentially store and decrypt once we receive the packet
+      // drop it for now
+      return;
+    }
+    // We could be in the AwaitingResponse state. If so, this message could establish a new
+    // session with a node. We keep track to see if the decryption uupdates the session. If so,
+    // we notify the user and flush all cached messages.
+    const sessionWasAwaiting = session.state.state === SessionState.AwaitingResponse;
+
+    // attempt to decrypt and process the message
+    let encodedMessage;
+    try {
+      encodedMessage = session.decryptMessage(packet.authTag, packet.message, packet.tag);
+    } catch (e) {
+      // We have a session but the message could not be decrypted.
+      // It is likely the node sending this message has dropped their session.
+      // In this case, this message is a random packet and we should reply with a WHOAREYOU.
+      // This means we need to drop the current session and re-establish.
+      this.sessions.delete(srcIdHex);
+      this.emit("whoAreYouRequest", srcId, from, packet.authTag);
+      return;
+    }
+    let message: Message;
+    try {
+      message = decode(encodedMessage);
+    } catch (e) {
+      throw new Error(`Failed to decode message. Error: ${e.message}`);
+    }
+
+    // Remove any associated request from pendingRequests
+    const pendingRequests = this.pendingRequests.get(from);
+    if (pendingRequests) {
+      pendingRequests.delete(message.id);
+    }
+
+    // We have received a new message. Notify the protocol
+    this.emit("message", srcId, from, message);
+
+    // update the lastSeenSocket and check if we need to promote the sesison to trusted
+    session.lastSeenSocket = from;
+
+    // There are two possibilities as session could have been established.
+    // The lastest message matches the known ENR and upgrades the session to an established state,
+    // or, we were awaiting a message to be decrypted with new session keys,
+    // this just arrived and now we consider the session established.
+    // In both cases, we notify the user and fllush the cahced messages
+    if (
+      (session.updateTrusted() &&  session.trustedEstablished()) ||
+      (session.trustedEstablished() && sessionWasAwaiting)
+    ) {
+      // session has been established, notify the protocol
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.emit("established", session.remoteEnr!);
+      // flush messages
+      this.flushMessages(srcId, from);
+    }
+  }
+  public onPacket = (src: ISocketAddr, packet: Packet): void => {
+    switch (packet.type) {
+      case PacketType.WhoAreYou:
+        return this.onWhoAreYou(src, packet as IWhoAreYouPacket);
+      case PacketType.AuthMessage:
+        return this.onAuthMessage(src, packet as IAuthMessagePacket);
+      case PacketType.Message:
+        return this.onMessage(src, packet as IMessagePacket);
+    }
+  };
+
+  public updateEnr(enr: ENR): void {
+    const session = this.sessions.get(toHex(enr.nodeId));
+    if (session) {
+      if (session.updateEnr(enr)) {
+        // A session has be been promited to established.
+        this.emit("established", enr);
+      }
+    }
   }
 
-  public onPacket = (from: ISocketAddr, type: PacketType, packet: Packet): void => {
-    switch (type) {
-      case PacketType.WhoAreYou:
-        return this.onWhoAreYou(from, packet as IWhoAreYouPacket);
-      case PacketType.AuthMessage:
-        return this.onAuthMessage(from, packet as IAuthMessagePacket);
-      case PacketType.Message:
-        return this.onMessage(from, packet as IMessagePacket);
+  /**
+   * Sends an RequestMessage request to a known ENR.
+   * It is possible to send requests to IP addresses not related to the ENR.
+   */
+  public sendRequest(dstEnr: ENR, message: RequestMessage): void {
+    const dstId = dstEnr.nodeId;
+    const dstIdHex = toHex(dstId);
+    const dst = getUDPSocketAddr(dstEnr);
+    const session = this.sessions.get(dstIdHex);
+    if (!session) {
+      // cache message
+      const msgs = this.pendingMessages.get(dstIdHex);
+      if (msgs) {
+        msgs.push(message);
+      } else {
+        this.pendingMessages.set(dstIdHex, [message]);
+      }
+      // need to establish a new session, send a random packet
+      const [session, packet] = Session.createWithRandom(getTag(this.enr, dstId), dstEnr);
+      this.processRequest(dstId, dst, packet, message);
+      this.sessions.set(toHex(dstId), session);
+      return;
+    }
+    if (!session.trustedEstablished()) {
+      throw new Error("Session is being established, request failed");
+    }
+    if (!session.isTrusted()) {
+      throw new Error("Tried to send a request to an untrusted node");
+    }
+    // encrypt the message and send
+    const packet = session.encryptMessage(getTag(this.enr, dstId), encode(message));
+    this.processRequest(dstId, dst, packet, message);
+  }
+
+  /**
+   * Similar to `sendRequest` but for requests which an ENR may be unknown.
+   * A session is therefore assumed to be valid
+   */
+  public sendRequestUnknownEnr(dst: ISocketAddr, dstId: NodeId, message: RequestMessage): void {
+    // session should be established
+    const session = this.sessions.get(toHex(dstId));
+    if (!session) {
+      throw new Error("Session not established");
+    }
+
+    const packet = session.encryptMessage(getTag(this.enr, dstId), encode(message));
+    this.processRequest(dstId, dst, packet, message);
+  }
+
+  /**
+   * Sends a response
+   * This differs from `sendRequest` as responses do not require a known ENR to send messages
+   * and sessions should already be established
+   */
+  public sendResponse(dst: ISocketAddr, dstId: NodeId, message: ResponseMessage): void {
+    // session should be established
+    const session = this.sessions.get(toHex(dstId));
+    if (!session) {
+      throw new Error("Session not established");
+    }
+    const packet = session.encryptMessage(getTag(this.enr, dstId), encode(message));
+    this.transport.send(dst, packet);
+  }
+
+  public sendWhoAreYou(dst: ISocketAddr, dstId: NodeId, enrSeq: bigint, remoteEnr: ENR, authTag: AuthTag): void {
+    const dstIdHex = toHex(dstId);
+    // _session will be overwritten if not trusted-established or state.whoareyousent
+    const _session = this.sessions.get(dstIdHex);
+    if (_session) {
+      // If a WHOAREYOU is already sent or a session is already established, ignore this request
+      if (_session.trustedEstablished() || _session.state.state === SessionState.WhoAreYouSent) {
+        // session exists, WhoAreYou packet not sent
+        return;
+      }
+    }
+    const [session, packet] = Session.createWithWhoAreYou(dstId, enrSeq, remoteEnr, authTag);
+    this.sessions.set(dstIdHex, session);
+    this.processRequest(dstId, dst, packet);
+  }
+
+  private processRequest(dstId: NodeId, dst: ISocketAddr, packet: Packet, message?: RequestMessage): void {
+    const request: IPendingRequest = {
+      dstId,
+      dst,
+      packet,
+      message,
+      retries: 1,
+    };
+    this.transport.send(dst, packet);
+    let requests = this.pendingRequests.get(dst);
+    if (!requests) {
+      requests = new TimeoutMap(REQUEST_TIMEOUT, this.onPendingRequestTimeout);
+      this.pendingRequests.set(dst, requests);
+    }
+    requests.set(message ? message.id : 0n, request);
+  }
+
+  /**
+   * Encrypts and sends any messages (for a specific destination) that were waiting for a session to be established
+   */
+  private flushMessages(dstId: NodeId, dst: ISocketAddr): void {
+    const dstIdHex = toHex(dstId);
+    const session = this.sessions.get(dstIdHex);
+    if (!session || !session.trustedEstablished()) {
+      // No adequate session
+      return;
+    }
+    const tag = getTag(this.enr, dstId);
+
+    const messages = this.pendingMessages.get(dstIdHex) || [];
+    this.pendingMessages.delete(dstIdHex);
+    messages.forEach((message) => {
+      const packet = session.encryptMessage(tag, encode(message));
+      this.processRequest(dstId, dst, packet, message);
+    });
+  }
+
+  /**
+   * Remove timed-out requests
+   */
+  private onPendingRequestTimeout = (requestId: RequestId, request: IPendingRequest): void => {
+    if (request.retries >= REQUEST_RETRIES) {
+      const dstIdHex = toHex(request.dstId);
+      if (request.packet.type === PacketType.Random || request.packet.type === PacketType.WhoAreYou) {
+        // no response from peer, flush all pending messages and drop session
+        const pendingMessages = this.pendingMessages.get(dstIdHex);
+        if (pendingMessages) {
+          this.pendingMessages.delete(dstIdHex);
+          pendingMessages.forEach((message) =>
+            this.emit("requestFailed", request.dstId, message.id));
+        }
+        this.sessions.delete(dstIdHex);
+      } else if (request.packet.type === PacketType.AuthMessage || request.packet.type === PacketType.Message) {
+        this.emit("requestFailed", request.dstId, requestId);
+      }
+    } else {
+      // Increment the request retry count and restart the timeout
+      this.transport.send(request.dst, request.packet);
+      request.retries += 1;
+      let requests = this.pendingRequests.get(request.dst);
+      if (!requests) {
+        requests = new TimeoutMap(REQUEST_TIMEOUT, this.onPendingRequestTimeout);
+        this.pendingRequests.set(request.dst, requests);
+      }
+      requests.set(requestId, request);
     }
   };
 
   /**
-   * Contact a peer.
-   *
-   * The peer is also added to the routing table, evicting an existing peer if needed.
-   *
-   * @param enr the peer to contact.
+   * Handle timed-out sessions
+   * Only drop a session if we are not expecting any responses.
    */
-  public async addPeer(enr: ENR): Promise<void> {
-    const toEvict = this.routingTable.propose(enr);
-    if (toEvict != undefined) {
-      this.routingTable.evict(toEvict);
-      this.routingTable.propose(enr);
+  private onSessionTimeout = (nodeIdHex: NodeIdHex, session: Session): void => {
+    const nodeId = fromHex(nodeIdHex);
+    for (const pendingRequests of this.pendingRequests.values()) {
+      if (Array.from(pendingRequests.values()).find((request) => request.dstId.equals(nodeId))) {
+        this.sessions.setWithTimeout(nodeIdHex, session, REQUEST_TIMEOUT);
+        return;
+      }
     }
-
-    const existingSession = this.sessions.get(enr.nodeId);
-    if (existingSession == null) {
-      const tag = createAuthTag();
-      const [session, randomPacket] = Session.createWithRandom(tag, enr);
-
-      this.sessions.set(enr.nodeId, session);
-      await this.transport.send({
-        port: +enr.get("udp")!.toString(),
-        address: enr.get("ip")!.toString()
-      }, PacketType.AuthMessage, randomPacket);
-    }
-  }
-
-  /**
-   * Get a random peer.
-   * @return peer, or undefined if the peer table is empty.
-   */
-  public randomPeer(): ENR | undefined {
-    return this.routingTable.random();
-  }
+    // No pending requests for nodeId
+    // Fail all pending messages for this node
+    (this.pendingMessages.get(nodeIdHex) || [])
+      .forEach((message) => this.emit("requestFailed", nodeId, message.id));
+    this.pendingMessages.delete(nodeIdHex);
+  };
 }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -17,6 +17,7 @@ import {
   Nonce,
   Tag,
   PacketType,
+  IRandomPacket,
 } from "../packet";
 import {
   generateSessionKeys,
@@ -93,7 +94,7 @@ export class Session {
    * Creates a new `Session` instance and generates a RANDOM packet to be sent along with this
    * session being established. This session is set to `RandomSent` state.
    */
-  static createWithRandom(tag: Tag, remoteEnr: ENR): [Session, IMessagePacket] {
+  static createWithRandom(tag: Tag, remoteEnr: ENR): [Session, IRandomPacket] {
     return [
       new Session({
         state: {state: SessionState.RandomSent},

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,3 +1,8 @@
+import { NodeId, ENR } from "../enr";
+import { Packet, AuthTag } from "../packet";
+import { Message, RequestMessage } from "../message";
+import { ISocketAddr } from "../transport";
+
 export enum SessionState {
   /**
    * A WHOAREYOU packet has been sent, and the Session is awaiting an Authentication response.
@@ -60,4 +65,50 @@ export enum TrustedState {
    * connected until the IP is updated to match the source IP.
    */
   Untrusted,
+}
+
+/**
+ * A request to a node that we are waiting for a response
+ */
+export interface IPendingRequest {
+  /**
+   * The destination NodeId
+   */
+  dstId: NodeId;
+  /**
+   * The destination ISocketAddr
+   */
+  dst: ISocketAddr;
+  /**
+   * The raw packet sent
+   */
+  packet: Packet;
+  /**
+   * The unencrypted message. Required if we need to re-encrypt and re-send
+   */
+  message?: RequestMessage;
+  /**
+   * The number if times this request has been re-sent
+   */
+  retries: number;
+}
+
+export interface ISessionEvents {
+  /**
+   * A session has been established with a node
+   */
+  established: (enr: ENR) => void;
+  /**
+   * A message was received
+   */
+  message: (srcId: NodeId, src: ISocketAddr, message: Message) => void;
+  /**
+   * A WHOAREYOU packet needs to be sent.
+   * This requests the protocol layer to send back the highest known ENR.
+   */
+  whoAreYouRequest: (srcId: NodeId, src: ISocketAddr, authTag: AuthTag) => void;
+  /**
+   * An RPC request failed.
+   */
+  requestFailed: (srcId: NodeId, rpcId: bigint) => void;
 }

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
+export * from "./util";
 export * from "./udp";

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -1,3 +1,6 @@
+import { EventEmitter } from "events";
+import StrictEventEmitter from "strict-event-emitter-types";
+
 import {
   Packet,
 } from "../packet";
@@ -14,7 +17,13 @@ export interface IRemoteInfo {
   size: number;
 }
 
-export interface ITransportService {
+export interface ITransportEvents {
+  packet: (src: ISocketAddr, packet: Packet) => void;
+  error: (err: Error, src: ISocketAddr) => void;
+}
+export type TransportEventEmitter = StrictEventEmitter<EventEmitter, ITransportEvents>;
+
+export interface ITransportService extends TransportEventEmitter {
   start(): Promise<void>;
   close(): Promise<void>;
   send(to: ISocketAddr, packet: Packet): Promise<void>;

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -1,6 +1,5 @@
 import {
   Packet,
-  PacketType,
 } from "../packet";
 
 export interface ISocketAddr {
@@ -18,9 +17,5 @@ export interface IRemoteInfo {
 export interface ITransportService {
   start(): Promise<void>;
   close(): Promise<void>;
-  send(to: ISocketAddr, type: PacketType, packet: Packet): Promise<void>;
-
-  on(packet: string, onPacket: (from: ISocketAddr, type: PacketType, packet: Packet) => void): void;
-
-  removeListener(packet: string, onPacket: (from: ISocketAddr, type: PacketType, packet: Packet) => void): void;
+  send(to: ISocketAddr, packet: Packet): Promise<void>;
 }

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -10,6 +10,8 @@ export interface ISocketAddr {
   address: string;
 }
 
+export type SocketAddrStr = string;
+
 export interface IRemoteInfo {
   address: string;
   family: "IPv4" | "IPv6";

--- a/src/transport/udp.ts
+++ b/src/transport/udp.ts
@@ -45,8 +45,8 @@ export class UDPTransportService extends EventEmitter implements ITransportServi
     return new Promise((resolve) => this.socket.close(resolve));
   }
 
-  public async send(to: ISocketAddr, type: PacketType, packet: Packet): Promise<void> {
-    return new Promise((resolve) => this.socket.send(encode(type, packet), to.port, to.address, () => resolve()));
+  public async send(to: ISocketAddr, packet: Packet): Promise<void> {
+    return new Promise((resolve) => this.socket.send(encode(packet), to.port, to.address, () => resolve()));
   }
 
   public handleIncoming = (data: Buffer, rinfo: IRemoteInfo): void => {
@@ -55,8 +55,8 @@ export class UDPTransportService extends EventEmitter implements ITransportServi
       port: rinfo.port,
     };
     try {
-      const [type, packet] = decode(data, this.whoAreYouMagic);
-      this.emit("packet", sender, type, packet);
+      const packet = decode(data, this.whoAreYouMagic);
+      this.emit("packet", sender, packet);
     } catch (e) {
       this.emit("error", e, sender);
     }

--- a/src/transport/udp.ts
+++ b/src/transport/udp.ts
@@ -5,20 +5,22 @@ import {
   decode,
   encode,
   Packet,
-  PacketType,
   MAX_PACKET_SIZE,
 } from "../packet";
 import {
   ISocketAddr,
   IRemoteInfo,
   ITransportService,
+  TransportEventEmitter,
 } from "./types";
 
 
 /**
  * This class is responsible for encoding outgoing Packets and decoding incoming Packets over UDP
  */
-export class UDPTransportService extends EventEmitter implements ITransportService {
+export class UDPTransportService
+  extends (EventEmitter as { new(): TransportEventEmitter })
+  implements ITransportService {
 
   private socketAddr: ISocketAddr;
   private socket: dgram.Socket;

--- a/src/transport/util.ts
+++ b/src/transport/util.ts
@@ -1,0 +1,5 @@
+import { ISocketAddr, SocketAddrStr } from "./types";
+
+export function toSocketAddrStr(socketAddr: ISocketAddr): SocketAddrStr {
+  return socketAddr.address + ":" + socketAddr.port;
+}

--- a/src/util/hexString.ts
+++ b/src/util/hexString.ts
@@ -1,0 +1,7 @@
+export function toHex(buf: Buffer): string {
+  return buf.toString("hex");
+}
+
+export function fromHex(str: string): Buffer {
+  return Buffer.from(str, "hex");
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,2 @@
+export * from "./hexString";
+export * from "./timeoutMap";

--- a/src/util/timeoutMap.ts
+++ b/src/util/timeoutMap.ts
@@ -1,0 +1,62 @@
+/**
+ * TimeoutMap is a map that evicts values after a certain timeout
+ * A callback, onTimeout, can optionally be registered which will be called upon each value's timeout
+ */
+export class TimeoutMap<K, V> extends Map<K, V> {
+  public onTimeout: ((k: K, v: V) => void) | undefined;
+  private timeout: number;
+  private timeouts: Map<K, NodeJS.Timeout>;
+
+  constructor(timeout: number, onTimeout?: (k: K, v: V) => void) {
+    super();
+    this.timeout = timeout;
+    this.onTimeout = onTimeout;
+    this.timeouts = new Map();
+  }
+
+  setTimeout(key: K, timeout: number): void {
+    if (!this.get(key)) {
+      return;
+    }
+    clearTimeout(this.timeouts.get(key) as NodeJS.Timeout);
+    this.timeouts.set(
+      key,
+      setTimeout(() => {
+        const value = this.get(key);
+        this.delete(key);
+        this.timeouts.delete(key);
+
+        if (this.onTimeout) {
+          this.onTimeout(key, value as V);
+        }
+      }, timeout)
+    );
+  }
+
+  setWithTimeout(key: K, value: V, timeout: number): this {
+    // value map set
+    super.set(key, value);
+    // timeout map set
+    this.setTimeout(key, timeout);
+    return this;
+  }
+
+  set(key: K, value: V): this {
+    return this.setWithTimeout(key, value, this.timeout);
+  }
+
+  delete(key: K): boolean {
+    const deleted = super.delete(key);
+    clearTimeout(this.timeouts.get(key) as NodeJS.Timeout);
+    this.timeouts.delete(key);
+    return deleted;
+  }
+
+  clear(): void {
+    super.clear();
+    for (const t of this.timeouts.values()) {
+      clearTimeout(t);
+    }
+    this.timeouts.clear();
+  }
+}

--- a/test/message/codec.test.ts
+++ b/test/message/codec.test.ts
@@ -5,46 +5,46 @@ import { ENR } from "../../src/enr";
 describe("message", () => {
   const testCases: {
     message: Message;
-    type: MessageType;
     expected: Buffer;
   }[] = [
     {
       message: {
+        type: MessageType.PING,
         id: 1n,
         enrSeq: 1n,
       },
-      type: MessageType.PING,
       expected: Buffer.from("01c20101", "hex"),
     },
     {
       message: {
+        type: MessageType.PONG,
         id: 1n,
         enrSeq: 1n,
         recipientIp: "127.0.0.1",
         recipientPort: 5000,
       },
-      type: MessageType.PONG,
       expected: Buffer.from("02ca0101847f000001821388", "hex"),
     },
     {
       message: {
+        type: MessageType.FINDNODE,
         id: 1n,
         distance: 256,
       },
-      type: MessageType.FINDNODE,
       expected: Buffer.from("03c401820100", "hex"),
     },
     {
       message: {
+        type: MessageType.NODES,
         id: 1n,
         total: 1,
         enrs: [],
       },
-      type: MessageType.NODES,
       expected: Buffer.from("04c30101c0", "hex"),
     },
     {
       message: {
+        type: MessageType.NODES,
         id: 1n,
         total: 1,
         enrs: [
@@ -52,15 +52,14 @@ describe("message", () => {
           ENR.decodeTxt("enr:-HW4QNfxw543Ypf4HXKXdYxkyzfcxcO-6p9X986WldfVpnVTQX1xlTnWrktEWUbeTZnmgOuAY_KUhbVV1Ft98WoYUBMBgmlkgnY0iXNlY3AyNTZrMaEDDiy3QkHAxPyOgWbxp5oF1bDdlYE6dLCUUp8xfVw50jU"),
         ],
       },
-      type: MessageType.NODES,
       expected: Buffer.from("04f8f20101f8eef875b8401ce2991c64993d7c84c29a00bdc871917551c7d330fca2dd0d69c706596dc655448f030b98a77d4001fd46ae0112ce26d613c5a6a02a81a6223cd0c4edaa53280182696482763489736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138f875b840d7f1c39e376297f81d7297758c64cb37dcc5c3beea9f57f7ce9695d7d5a67553417d719539d6ae4b445946de4d99e680eb8063f29485b555d45b7df16a1850130182696482763489736563703235366b31a1030e2cb74241c0c4fc8e8166f1a79a05d5b0dd95813a74b094529f317d5c39d235", "hex"),
     },
   ];
-  for (const {message, type, expected} of testCases) {
-    it(`should encode/decode message type ${MessageType[type]}`, () => {
-      const actual = encode(type, message);
+  for (const {message, expected} of testCases) {
+    it(`should encode/decode message type ${MessageType[message.type]}`, () => {
+      const actual = encode(message);
       // expect(actual).to.deep.equal(expected);
-      expect(decode(actual)).to.deep.equal([type, message]);
+      expect(decode(actual)).to.deep.equal(message);
     });
   }
 

--- a/test/packet/codec.test.ts
+++ b/test/packet/codec.test.ts
@@ -18,16 +18,15 @@ describe("Packet - known test vectors", () => {
     const authTag = Buffer.from("020202020202020202020202", "hex");
     const message = Buffer.from("0404040404040404040404040404040404040404040404040404040404040404040404040404040404040404", "hex");
     const p0: IMessagePacket = {
+      type: PacketType.Message,
       tag,
       authTag,
       message,
     };
     const expected = Buffer.from("01010101010101010101010101010101010101010101010101010101010101018c0202020202020202020202020404040404040404040404040404040404040404040404040404040404040404040404040404040404040404", "hex");
-    const typ0 = PacketType.Message;
-    const b0 = encode(typ0, p0);
+    const b0 = encode(p0);
     expect(b0).to.deep.equal(expected);
-    const [typ1, p1] = decode(b0, magic);
-    expect(typ1).to.equal(typ0);
+    const p1 = decode(b0, magic);
     expect(p1).to.deep.equal(p0);
   });
 
@@ -37,17 +36,16 @@ describe("Packet - known test vectors", () => {
     const idNonce = Buffer.from("0303030303030303030303030303030303030303030303030303030303030303", "hex");
     const enrSeq = 1;
     const p0: IWhoAreYouPacket = {
+      type: PacketType.WhoAreYou,
       magic,
       token,
       idNonce,
       enrSeq,
     };
     const expected = Buffer.from("0101010101010101010101010101010101010101010101010101010101010101ef8c020202020202020202020202a0030303030303030303030303030303030303030303030303030303030303030301", "hex");
-    const typ0 = PacketType.WhoAreYou;
-    const b0 = encode(typ0, p0);
+    const b0 = encode(p0);
     expect(b0).to.deep.equal(expected);
-    const [typ1, p1] = decode(b0, magic);
-    expect(typ1).to.equal(typ0);
+    const p1 = decode(b0, magic);
     expect(p1).to.deep.equal(p0);
   });
 
@@ -60,6 +58,7 @@ describe("Packet - known test vectors", () => {
     const authResponse = Buffer.from("570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852", "hex");
     const message = Buffer.from("a5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
     const p0: IAuthMessagePacket = {
+      type: PacketType.AuthMessage,
       tag,
       authHeader: {
         authTag,
@@ -71,11 +70,9 @@ describe("Packet - known test vectors", () => {
       message,
     };
     const expected = Buffer.from("93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903f8cc8c27b5af763c446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c658367636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852a5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
-    const typ0 = PacketType.AuthMessage;
-    const b0 = encode(typ0, p0);
+    const b0 = encode(p0);
     expect(b0).to.deep.equal(expected);
-    const [typ1, p1] = decode(b0, magic);
-    expect(typ1).to.equal(typ0);
+    const p1 = decode(b0, magic);
     expect(p1).to.deep.equal(p0);
   });
 
@@ -85,16 +82,15 @@ describe("Packet - known test vectors", () => {
     const authTag = Buffer.from("27b5af763c446acd2749fe8e", "hex");
     const message = Buffer.from("a5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
     const p0: IMessagePacket = {
+      type: PacketType.Message,
       tag,
       authTag,
       message,
     };
     const expected = Buffer.from("93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f421079038c27b5af763c446acd2749fe8ea5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
-    const typ0 = PacketType.Message;
-    const b0 = encode(typ0, p0);
+    const b0 = encode(p0);
     expect(b0).to.deep.equal(expected);
-    const [typ1, p1] = decode(b0, magic);
-    expect(typ1).to.equal(typ0);
+    const p1 = decode(b0, magic);
     expect(p1).to.deep.equal(p0);
   });
 });

--- a/test/service/service.test.ts
+++ b/test/service/service.test.ts
@@ -1,18 +1,20 @@
 /* eslint-env mocha */
 /* eslint-disable max-len */
-import {expect} from "chai";
+import { expect } from "chai";
+import { capture, instance, mock } from "ts-mockito";
+
 import Service from "../../src/service/service";
-import {ENR, v4} from "../../src/enr";
-import {SessionService} from "../../src/session/service";
-import {ISocketAddr, UDPTransportService} from "../../src/transport";
-import {capture, instance, mock} from "ts-mockito";
-import {IAuthMessagePacket, PacketType} from "../../src/packet";
+import { ENR, v4 } from "../../src/enr";
+import { SessionService } from "../../src/session/service";
+import { ISocketAddr, UDPTransportService } from "../../src/transport";
+import { IAuthMessagePacket, PacketType } from "../../src/packet";
+import { generateKeypair, KeypairType } from "../../src/keypair";
 
 describe("Service", () => {
-  const sk = v4.createPrivateKey();
-  const enr = ENR.createV4(v4.publicKey(sk));
+  const kp = generateKeypair(KeypairType.secp256k1);
+  const enr = ENR.createV4(kp.publicKey);
   it("should start and stop", async () => {
-    const service = Service.create(enr);
+    const service = Service.create(enr, kp);
     await service.start();
     expect(service.started).to.be.true;
     await service.stop();
@@ -20,7 +22,7 @@ describe("Service", () => {
   });
 
   it("should stop twice without problems", async () => {
-    const service = Service.create(enr);
+    const service = Service.create(enr, kp);
     await service.start();
     expect(service.started).to.be.true;
     await service.stop();
@@ -30,30 +32,31 @@ describe("Service", () => {
   });
 
   it("should bind to 0.0.0.0 by default", () => {
-    const service = Service.create(enr);
+    const service = Service.create(enr, kp);
     expect(service.networkInterface).eq("0.0.0.0");
   });
 
   it("should use port 30303 by default", () => {
-    const service = Service.create(enr);
+    const service = Service.create(enr, kp);
     expect(service.port).eq(30303);
   });
 
   it("should validate ports", () => {
-    expect(() => { Service.create(enr, 0); }).to.throw("Invalid port number 0. It should be between 1 and 65535.");
-    expect(() => { Service.create(enr, 100000); }).to.throw("Invalid port number 100000. It should be between 1 and 65535.");
+    expect(() => { Service.create(enr, kp, 0); }).to.throw("Invalid port number 0. It should be between 1 and 65535.");
+    expect(() => { Service.create(enr, kp, 100000); }).to.throw("Invalid port number 100000. It should be between 1 and 65535.");
   });
 
   it("should allow to pick a port and network interface", () => {
-    const service = Service.create(enr, 300, "127.0.0.1");
+    const service = Service.create(enr, kp, 300, "127.0.0.1");
     expect(service.port).eq(300);
     expect(service.networkInterface).eq("127.0.0.1");
   });
 
+  /*
   it("should add new peers", async () => {
     const mockTransportService = mock(UDPTransportService);
     const serviceMock: UDPTransportService = instance(mockTransportService);
-    const service = new Service(enr, 15000, "0.0.0.0", [], new SessionService(enr, serviceMock));
+    const service = new Service(enr, kp, 15000, "0.0.0.0", [], new SessionService(enr, serviceMock));
     const sk = v4.createPrivateKey();
     const peerENR = ENR.createV4(v4.publicKey(sk), {"ip": Buffer.from("127.0.0.1"), "udp": Buffer.from("10000")});
     await service.addPeer(peerENR);
@@ -63,4 +66,5 @@ describe("Service", () => {
     expect(to.port).eq(10000);
     expect(type).eq(PacketType.AuthMessage);
   });
+   */
 });

--- a/test/session/crypto.test.ts
+++ b/test/session/crypto.test.ts
@@ -113,7 +113,8 @@ describe("session crypto", () => {
 
     const expectedAuthMessageRlp = Buffer.from("93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903f8cc8c27b5af763c446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c658367636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852a5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
 
-    expect(encode(PacketType.AuthMessage, {
+    expect(encode({
+      type: PacketType.AuthMessage,
       tag,
       authHeader,
       message: encryptMessage(

--- a/test/session/service.test.ts
+++ b/test/session/service.test.ts
@@ -1,0 +1,45 @@
+/* eslint-env mocha */
+import { createKeypair, KeypairType } from "../../src/keypair";
+import { ENR, setUDPSocketAddr } from "../../src/enr";
+import { createMagic } from "../../src/packet";
+import { UDPTransportService } from "../../src/transport";
+import { SessionService } from "../../src/session";
+
+describe("session service", () => {
+  const kp0 = createKeypair(
+    KeypairType.secp256k1,
+    Buffer.from("a93bedf04784c937059557c9dcb328f5f59fdb6e89295c30e918579250b7b01f", "hex"),
+    Buffer.from("022663242e1092ea19e6bb41d67aa69850541a623b94bbea840ddceaab39789894", "hex"),
+  );
+  const kp1 = createKeypair(
+    KeypairType.secp256k1,
+    Buffer.from("bd04e55f2a1424a4e69e96aad41cf763d2468d4358472e9f851569bdf47fb24c", "hex"),
+    Buffer.from("03eae9945b354e9212566bc3f2740f3a62b3e1eb227dbed809f6dc2d3ea848c82e", "hex"),
+  );
+
+  const addr0 = { address: "127.0.0.1", port: 49020 };
+  const addr1 = { address: "127.0.0.1", port: 49021 };
+
+  const enr0 = ENR.createV4(kp0.publicKey);
+  const enr1 = ENR.createV4(kp1.publicKey);
+
+  setUDPSocketAddr(enr0, addr0);
+  setUDPSocketAddr(enr1, addr1);
+
+  const magic0 = createMagic(enr0.nodeId);
+  const magic1 = createMagic(enr1.nodeId);
+
+  it("start/close service", async () => {
+    const transport0 = new UDPTransportService(addr0, magic0);
+    const transport1 = new UDPTransportService(addr1, magic1);
+
+    const service0 = new SessionService(enr0, kp0, transport0);
+    const service1 = new SessionService(enr1, kp1, transport1);
+
+    await service0.start();
+    await service1.start();
+
+    await service0.close();
+    await service1.close();
+  });
+});

--- a/test/transport/udp.test.ts
+++ b/test/transport/udp.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import {PacketType, TAG_LENGTH, AUTH_TAG_LENGTH, MAGIC_LENGTH} from "../../src/packet";
+import {PacketType, TAG_LENGTH, AUTH_TAG_LENGTH, MAGIC_LENGTH, IMessagePacket} from "../../src/packet";
 import {UDPTransportService} from "../../src/transport";
 import { expect } from "chai";
 
@@ -24,23 +24,22 @@ describe("UDP transport", () => {
   });
 
   it("should send and receive messages", async () => {
-    const messagePacket = {
+    const messagePacket: IMessagePacket = {
+      type: PacketType.Message,
       tag: Buffer.alloc(TAG_LENGTH),
       authTag: Buffer.alloc(AUTH_TAG_LENGTH),
       message: Buffer.alloc(44, 1),
     };
     const received = new Promise((resolve) =>
-      a.once("packet", (sender, type, packet) =>
-        resolve([sender, type, packet])));
+      a.once("packet", (sender, packet) =>
+        resolve([sender, packet])));
     await b.send(
       {port: portA, address},
-      PacketType.Message,
       messagePacket,
     );
     // @ts-ignore
-    const [rSender, rType, rPacket] = await received;
+    const [rSender, rPacket] = await received;
     expect(rSender).to.deep.equal({port: portB, address});
-    expect(rType).to.equal(PacketType.Message);
     expect(rPacket).to.deep.equal(messagePacket);
   });
 });

--- a/test/util/timeoutMap.test.ts
+++ b/test/util/timeoutMap.test.ts
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+import { expect } from "chai";
+
+import { TimeoutMap } from "../../src/util";
+
+describe("TimeoutMap", () => {
+  it("should evict items after a timeout", async function () {
+    const timeout = 15;
+    const map = new TimeoutMap(timeout);
+    map.set("foo", "bar");
+    await new Promise(resolve => setTimeout(resolve, timeout + 1));
+    expect(map.size).to.equal(0);
+  });
+  it("should call onTimeout after a timeout", async function () {
+    const timeout = 15;
+    let callbackCalled = false;
+    const map = new TimeoutMap(timeout, (k, v) => {
+      expect(k).to.equal("foo");
+      expect(v).to.equal("bar");
+      callbackCalled = true;
+    });
+    map.set("foo", "bar");
+    await new Promise(resolve => setTimeout(resolve, timeout + 1));
+    expect(map.size).to.equal(0);
+    expect(callbackCalled).to.equal(true);
+  });
+  it("should update a timeout", async function () {
+    const timeout = 15;
+    const map = new TimeoutMap(timeout);
+    map.set("foo", "bar");
+    map.setTimeout("foo", timeout * 2);
+    await new Promise(resolve => setTimeout(resolve, timeout));
+    expect(map.size).to.equal(1);
+    await new Promise(resolve => setTimeout(resolve, timeout + 1));
+    expect(map.size).to.equal(0);
+  });
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2456,6 +2456,11 @@ streamroller@^1.0.6:
     fs-extra "^7.0.1"
     lodash "^4.17.14"
 
+strict-event-emitter-types@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz#05e15549cb4da1694478a53543e4e2f4abcf277f"
+  integrity sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==
+
 "string-width@^1.0.2 || 2":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"


### PR DESCRIPTION
- Add `type` to `Packet` and `Message` (now packets and messages can be inspected to determine their types)
- Add strict event emitter to `ITransportService` and `SessionService` for well defined event types
- Temporarily blank out `Discv5Service` `addPeer` logic and test (will be re-implemented/re-enabled in a future PR)
- fill out `SessionService` - tracks the state of all sessions <-- this is the meat of the PR