### PR TITLE
v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.1 - (2020-05-07)
+
+### Features
+
+* allow enr input as a string ([840573](https://github.com/ChainSafe/discv5/commit/840573))
+
 ## 0.2.0 - (2020-04-24)
 
 ### Chores
@@ -7,6 +13,10 @@
 ### BREAKING CHANGES
 
 BREAKING CHANGE: emitted peer event now emits a peer data object with id and multiaddrs instead of a peer-info
+
+## 0.1.2 - (2020-05-07)
+
+* allow enr input as a string ([852129](https://github.com/ChainSafe/discv5/commit/852129))
 
 ## 0.1.1 - (2020-04-10)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/discv5",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Discovery V5",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Will release `v0.2.1` under `beta` dist tag,
Will backport changelog to `v0.1.x` branch and release `v0.1.2` as well