### PR TITLE
Add build on prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "check-types": "tsc --noEmit",
     "build": "tsc --declaration --outDir lib",
+    "prepublishOnly": "yarn build",
     "lint": "eslint --color --ext .ts src/",
     "test": "mocha -r ts-node/register 'test/**/*.test.ts'"
   },


### PR DESCRIPTION
0.2.3 publishing failed (practically speaking) pushing an old build to npm.
Add a prepublishOnly script to avoid in the future.
Will be followed up immediately with a 0.2.4 PR/release.