### PR TITLE
Add prettier as an eslint plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,12 +14,14 @@ module.exports = {
   },
   plugins: [
     "@typescript-eslint",
+    "prettier"
   ],
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
   ],
   rules: {
+    "prettier/prettier": "error",
     //doesnt work, it reports false errors
     "constructor-super": "off",
     "@typescript-eslint/class-name-casing": "error",
@@ -27,7 +29,6 @@ module.exports = {
       "allowExpressions": true
     }],
     "@typescript-eslint/func-call-spacing": "error",
-    "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/interface-name-prefix": ["error", "always"],
     "@typescript-eslint/member-ordering": "error",
     "@typescript-eslint/no-explicit-any": "error",

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  printWidth: 120,
+  tabWidth: 2,
+  useTabs: false,
+  semi: true,
+  singleQuote: false,
+  quoteProps: "as-needed",
+  trailingComma: "es5",
+  bracketSpacing: true,
+  arrowParens: "always",
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,31 @@
 
 ### Chores
 
-* Add build to prepublishOnly script ([23f1c7](https://github.com/ChainSafe/discv5/commit/23f1c7))
+- Add build to prepublishOnly script ([23f1c7](https://github.com/ChainSafe/discv5/commit/23f1c7))
 
 # 0.2.3 - (2020-06-24) INVALID/DEPRECATED
 
 ### Bugfixes
 
-* Add validations to ENR verification ([f5c53f](https://github.com/ChainSafe/discv5/commit/f5c53f))
+- Add validations to ENR verification ([f5c53f](https://github.com/ChainSafe/discv5/commit/f5c53f))
 
 ## 0.2.2 - (2020-05-21)
 
 ### Bugfixes
 
-* Fix startup bugs in libp2p compat ([55b2de](https://github.com/ChainSafe/discv5/commit/55b2de))
+- Fix startup bugs in libp2p compat ([55b2de](https://github.com/ChainSafe/discv5/commit/55b2de))
 
 ## 0.2.1 - (2020-05-07)
 
 ### Features
 
-* allow enr input as a string ([840573](https://github.com/ChainSafe/discv5/commit/840573))
+- allow enr input as a string ([840573](https://github.com/ChainSafe/discv5/commit/840573))
 
 ## 0.2.0 - (2020-04-24)
 
 ### Chores
 
-* chore: use new peer-discovery interface ([9950fb](https://github.com/ChainSafe/discv5/commit/9950fb))
+- chore: use new peer-discovery interface ([9950fb](https://github.com/ChainSafe/discv5/commit/9950fb))
 
 ### BREAKING CHANGES
 
@@ -36,16 +36,16 @@ BREAKING CHANGE: emitted peer event now emits a peer data object with id and mul
 
 ### Bugfixes
 
-* Fix startup bugs in libp2p compat ([ae97fa](https://github.com/ChainSafe/discv5/commit/ae97fa))
+- Fix startup bugs in libp2p compat ([ae97fa](https://github.com/ChainSafe/discv5/commit/ae97fa))
 
 ## 0.1.2 - (2020-05-07)
 
-* allow enr input as a string ([852129](https://github.com/ChainSafe/discv5/commit/852129))
+- allow enr input as a string ([852129](https://github.com/ChainSafe/discv5/commit/852129))
 
 ## 0.1.1 - (2020-04-10)
 
-* add libp2p peer-discovery compatibility module ([1cf660](https://github.com/ChainSafe/discv5/commit/1cf660))
+- add libp2p peer-discovery compatibility module ([1cf660](https://github.com/ChainSafe/discv5/commit/1cf660))
 
 ## 0.1.0 - (2020-04-06)
 
-* initial release
+- initial release

--- a/package.json
+++ b/package.json
@@ -44,9 +44,11 @@
     "@typescript-eslint/parser": "^2.7.0",
     "chai": "^4.2.0",
     "eslint": "^6.6.0",
+    "eslint-plugin-prettier": "^3.1.4",
     "karma": "^4.3.0",
     "mocha": "^6.2.0",
     "nyc": "^14.1.1",
+    "prettier": "^2.0.5",
     "ts-node": "^8.3.0",
     "typescript": "^3.8.3"
   },

--- a/src/enr/enr.ts
+++ b/src/enr/enr.ts
@@ -21,8 +21,8 @@ export class ENR extends Map<ENRKey, ENRValue> {
   static createV4(publicKey: Buffer, kvs: Record<ENRKey, ENRValue> = {}): ENR {
     return new ENR({
       ...kvs,
-      "id": Buffer.from("v4"),
-      "secp256k1": publicKey,
+      id: Buffer.from("v4"),
+      secp256k1: publicKey,
     });
   }
   static createFromPeerId(peerId: PeerId, kvs: Record<ENRKey, ENRValue> = {}): ENR {
@@ -53,7 +53,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
     return enr;
   }
   static decode(encoded: Buffer): ENR {
-    const decoded = RLP.decode(encoded) as unknown as Buffer[];
+    const decoded = (RLP.decode(encoded) as unknown) as Buffer[];
     return ENR.decodeFromValues(decoded);
   }
   static decodeTxt(encoded: string): ENR {
@@ -114,7 +114,9 @@ export class ENR extends Map<ENRKey, ENRValue> {
     if (ip6) {
       const udp6 = this.get("udp6");
       if (udp6) {
-        const ip6Str = Array.from(Uint16Array.from(ip6)).map((n) => n.toString(16)).join(":");
+        const ip6Str = Array.from(Uint16Array.from(ip6))
+          .map((n) => n.toString(16))
+          .join(":");
         return Multiaddr(`/ip6/${ip6Str}/udp/${udp6.readUInt16BE(0)}`);
       }
     }
@@ -152,7 +154,9 @@ export class ENR extends Map<ENRKey, ENRValue> {
     if (ip6) {
       const tcp6 = this.get("tcp6");
       if (tcp6) {
-        const ip6Str = Array.from(Uint16Array.from(ip6)).map((n) => n.toString(16)).join(":");
+        const ip6Str = Array.from(Uint16Array.from(ip6))
+          .map((n) => n.toString(16))
+          .join(":");
         return Multiaddr(`/ip6/${ip6Str}/tcp/${tcp6.readUInt16BE(0)}`);
       }
     }
@@ -175,7 +179,6 @@ export class ENR extends Map<ENRKey, ENRValue> {
       this.set("ip6", tuples[0][1]);
       this.set("tcp6", tuples[1][1]);
     }
-
   }
   verify(data: Buffer, signature: Buffer): boolean {
     if (!this.get("id") || this.id !== "v4") {
@@ -200,7 +203,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
     // sort keys and flatten into [k, v, k, v, ...]
     const content: Array<ENRKey | ENRValue | number> = Array.from(this.keys())
       .sort((a, b) => a.localeCompare(b))
-      .map((k) => ([k, this.get(k)] as [ENRKey, ENRValue]))
+      .map((k) => [k, this.get(k)] as [ENRKey, ENRValue])
       .flat();
     content.unshift(Number(this.seq));
     if (privateKey) {

--- a/src/enr/index.ts
+++ b/src/enr/index.ts
@@ -4,4 +4,3 @@ export * from "./constants";
 export * from "./enr";
 export * from "./types";
 export * from "./create";
-

--- a/src/enr/v4.ts
+++ b/src/enr/v4.ts
@@ -17,10 +17,7 @@ export function publicKey(privKey: Buffer): Buffer {
 }
 
 export function sign(privKey: Buffer, msg: Buffer): Buffer {
-  return secp256k1.sign(
-    hash(msg),
-    privKey,
-  );
+  return secp256k1.sign(hash(msg), privKey);
 }
 
 export function verify(pubKey: Buffer, msg: Buffer, sig: Buffer): boolean {

--- a/src/kademlia/bucket.ts
+++ b/src/kademlia/bucket.ts
@@ -3,8 +3,7 @@ import { EventEmitter } from "events";
 import { ENR, NodeId } from "../enr";
 import { BucketEventEmitter, EntryStatus, IEntry, IEntryFull } from "./types";
 
-
-export class Bucket extends (EventEmitter as { new(): BucketEventEmitter }) {
+export class Bucket extends (EventEmitter as { new (): BucketEventEmitter }) {
   private k: number;
   /**
    * Entries ordered from least-recently connected to most-recently connected
@@ -27,7 +26,7 @@ export class Bucket extends (EventEmitter as { new(): BucketEventEmitter }) {
   clear(): void {
     this.bucket = [];
     this.pending = undefined;
-    clearTimeout(this.pendingTimeoutId as unknown as NodeJS.Timeout);
+    clearTimeout((this.pendingTimeoutId as unknown) as NodeJS.Timeout);
   }
 
   /**
@@ -68,7 +67,7 @@ export class Bucket extends (EventEmitter as { new(): BucketEventEmitter }) {
 
   addConnected(value: ENR): boolean {
     if (this.bucket.length < this.k) {
-      this.bucket.push({value, status: EntryStatus.Connected});
+      this.bucket.push({ value, status: EntryStatus.Connected });
       return true;
     }
     // attempt to add a pending node
@@ -81,10 +80,10 @@ export class Bucket extends (EventEmitter as { new(): BucketEventEmitter }) {
     if (this.bucket.length < this.k) {
       if (firstConnected === -1) {
         // No connected nodes, add to the end
-        this.bucket.push({value, status: EntryStatus.Disconnected});
+        this.bucket.push({ value, status: EntryStatus.Disconnected });
       } else {
         // add before the first connected node
-        this.bucket.splice(firstConnected, 0, {value, status: EntryStatus.Disconnected});
+        this.bucket.splice(firstConnected, 0, { value, status: EntryStatus.Disconnected });
       }
       return true;
     }

--- a/src/kademlia/kademlia.ts
+++ b/src/kademlia/kademlia.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 
 import { Bucket } from "./bucket";
-import { EntryStatus, IEntryFull, BucketEventEmitter }  from "./types";
+import { EntryStatus, IEntryFull, BucketEventEmitter } from "./types";
 import { NodeId, ENR } from "../enr";
 import { NUM_BUCKETS, PENDING_TIMEOUT } from "./constants";
 import { log2Distance } from "./util";
@@ -15,8 +15,7 @@ import { log2Distance } from "./util";
  * take the place of the oldest disconnected entry in the bucket
  * or be dropped after a timeout.
  */
-export class KademliaRoutingTable extends (EventEmitter as { new(): BucketEventEmitter }) {
-
+export class KademliaRoutingTable extends (EventEmitter as { new (): BucketEventEmitter }) {
   localId: NodeId;
   k: number;
   size: number;
@@ -94,7 +93,6 @@ export class KademliaRoutingTable extends (EventEmitter as { new(): BucketEventE
     return bucket.update(value, status);
   }
 
-
   /**
    * Gets the ENR if stored, does not include pending values
    */
@@ -113,7 +111,7 @@ export class KademliaRoutingTable extends (EventEmitter as { new(): BucketEventE
 
   nearest(id: NodeId, limit: number): ENR[] {
     const results: ENR[] = [];
-    this.buckets.forEach(bucket => {
+    this.buckets.forEach((bucket) => {
       results.push(...bucket.values());
     });
     results.sort((a, b) => {
@@ -129,13 +127,13 @@ export class KademliaRoutingTable extends (EventEmitter as { new(): BucketEventE
 
   values(): ENR[] {
     return this.buckets
-      .filter(bucket => !bucket.isEmpty())
-      .map(bucket => bucket.values())
+      .filter((bucket) => !bucket.isEmpty())
+      .map((bucket) => bucket.values())
       .flat();
   }
 
   random(): ENR | undefined {
-    const nonEmptyBuckets = this.buckets.filter(bucket => !bucket.isEmpty());
+    const nonEmptyBuckets = this.buckets.filter((bucket) => !bucket.isEmpty());
     if (nonEmptyBuckets.length == 0) {
       return undefined;
     }

--- a/src/kademlia/lookup.ts
+++ b/src/kademlia/lookup.ts
@@ -13,7 +13,7 @@ export function createLookupPeer(nodeId: NodeId, state: LookupPeerState): ILooku
   };
 }
 
-export class Lookup extends (EventEmitter as { new(): LookupEventEmitter }) {
+export class Lookup extends (EventEmitter as { new (): LookupEventEmitter }) {
   /**
    * Target we're looking for
    */
@@ -21,7 +21,7 @@ export class Lookup extends (EventEmitter as { new(): LookupEventEmitter }) {
   /**
    * Temporary ENRs used when trying to reach nodes
    */
-  untrustedEnrs: Record<NodeId,ENR>;
+  untrustedEnrs: Record<NodeId, ENR>;
   /**
    * The current state of the lookup
    */
@@ -63,15 +63,7 @@ export class Lookup extends (EventEmitter as { new(): LookupEventEmitter }) {
     this.closestPeers = new Map(
       closestPeers
         .slice(0, this.config.numResults)
-        .map((n) =>
-          ([
-            distance(nodeId, n),
-            createLookupPeer(n, LookupPeerState.NotContacted),
-          ] as [
-            bigint,
-            ILookupPeer
-          ])
-        )
+        .map((n) => [distance(nodeId, n), createLookupPeer(n, LookupPeerState.NotContacted)] as [bigint, ILookupPeer])
     );
   }
 
@@ -112,7 +104,7 @@ export class Lookup extends (EventEmitter as { new(): LookupEventEmitter }) {
    */
   closestPeersByDistance(): ILookupPeer[] {
     return Array.from(this.closestPeers.keys())
-      .sort((a, b) => b - a ? -1 : 1)
+      .sort((a, b) => (b - a ? -1 : 1))
       .map((dist) => this.closestPeers.get(dist) as ILookupPeer);
   }
 
@@ -169,14 +161,11 @@ export class Lookup extends (EventEmitter as { new(): LookupEventEmitter }) {
       closerPeers.forEach((cNodeId) => {
         const cDist = distance(this.target, cNodeId);
         if (!this.closestPeers.has(cDist)) {
-          this.closestPeers.set(
-            cDist,
-            createLookupPeer(cNodeId, LookupPeerState.NotContacted),
-          );
+          this.closestPeers.set(cDist, createLookupPeer(cNodeId, LookupPeerState.NotContacted));
         }
         // The lookup makes progress if the new peer is either closer to the target than any peer seen so far
         // or the lookup did not yet accumulate enough closest peers
-        const closest = Array.from(this.closestPeers.keys()).sort((a, b) => b > a ? -1 : 1)[0];
+        const closest = Array.from(this.closestPeers.keys()).sort((a, b) => (b > a ? -1 : 1))[0];
         progress = progress || closest === cDist || numClosest < this.config.numResults;
       });
 
@@ -274,7 +263,7 @@ export class Lookup extends (EventEmitter as { new(): LookupEventEmitter }) {
       // and the lookup is not waiting for any more results
       this.state = LookupState.Finished;
       this.emit("finished", this.closestNodesByDistance());
-    } // else 
+    } // else
     // The lookup is still waiting for results and/or not at capacity w.r.t.
     // the allowed parallelism, but there are no new peers to contact
   }

--- a/src/keypair/index.ts
+++ b/src/keypair/index.ts
@@ -32,12 +32,10 @@ export async function createPeerIdFromKeypair(keypair: IKeypair): Promise<PeerId
     case KeypairType.secp256k1:
       try {
         return await PeerId.createFromPrivKey(
-          (new supportedKeys.secp256k1.Secp256k1PrivateKey(keypair.privateKey, keypair.publicKey)).bytes
+          new supportedKeys.secp256k1.Secp256k1PrivateKey(keypair.privateKey, keypair.publicKey).bytes
         );
       } catch (e) {
-        return await PeerId.createFromPubKey(
-          (new supportedKeys.secp256k1.Secp256k1PublicKey(keypair.publicKey)).bytes
-        );
+        return await PeerId.createFromPubKey(new supportedKeys.secp256k1.Secp256k1PublicKey(keypair.publicKey).bytes);
       }
     default:
       throw new Error(ERR_TYPE_NOT_IMPLEMENTED);
@@ -47,9 +45,5 @@ export async function createPeerIdFromKeypair(keypair: IKeypair): Promise<PeerId
 export function createKeypairFromPeerId(peerId: PeerId): IKeypair {
   // pub/privkey bytes from peer-id are encoded in protobuf format
   const pub = keysPBM.PublicKey.decode(peerId.pubKey.bytes);
-  return createKeypair(
-    pub.Type as KeypairType,
-    peerId.privKey ? peerId.privKey.marshal() : undefined,
-    pub.Data,
-  );
+  return createKeypair(pub.Type as KeypairType, peerId.privKey ? peerId.privKey.marshal() : undefined, pub.Data);
 }

--- a/src/keypair/secp256k1.ts
+++ b/src/keypair/secp256k1.ts
@@ -21,7 +21,7 @@ export function secp256k1PublicKeyToRaw(publicKey: Buffer): Buffer {
 }
 
 export const Secp256k1Keypair: IKeypairClass = class Secp256k1Keypair extends AbstractKeypair implements IKeypair {
-  readonly type:  KeypairType;
+  readonly type: KeypairType;
 
   constructor(privateKey?: Buffer, publicKey?: Buffer) {
     let pub = publicKey;

--- a/src/keypair/types.ts
+++ b/src/keypair/types.ts
@@ -16,7 +16,7 @@ export interface IKeypair {
 }
 
 export interface IKeypairClass {
-  new(privateKey?: Buffer, publicKey?: Buffer): IKeypair;
+  new (privateKey?: Buffer, publicKey?: Buffer): IKeypair;
   generate(): IKeypair;
 }
 
@@ -24,16 +24,10 @@ export abstract class AbstractKeypair {
   readonly _privateKey?: Buffer;
   readonly _publicKey?: Buffer;
   constructor(privateKey?: Buffer, publicKey?: Buffer) {
-    if (
-      (this._privateKey = privateKey) &&
-      !this.privateKeyVerify()
-    ) {
+    if ((this._privateKey = privateKey) && !this.privateKeyVerify()) {
       throw new Error("Invalid private key");
     }
-    if (
-      (this._publicKey = publicKey) &&
-      !this.publicKeyVerify()
-    ) {
+    if ((this._publicKey = publicKey) && !this.publicKeyVerify()) {
       throw new Error("Invalid private key");
     }
   }

--- a/src/libp2p/discv5.ts
+++ b/src/libp2p/discv5.ts
@@ -71,7 +71,7 @@ export class Discv5Discovery extends EventEmitter {
       for (const enr of enrs) {
         this.emit("peer", {
           id: enr.peerId(),
-          multiaddrs: [Multiaddr(enr.multiaddrTCP)]
+          multiaddrs: [Multiaddr(enr.multiaddrTCP)],
         });
       }
     }

--- a/src/message/create.ts
+++ b/src/message/create.ts
@@ -4,7 +4,6 @@ import { toBigIntBE } from "bigint-buffer";
 import { RequestId, IPingMessage, MessageType, IPongMessage, IFindNodeMessage, INodesMessage } from "./types";
 import { SequenceNumber, ENR } from "../enr";
 
-
 export function createRequestId(): RequestId {
   return toBigIntBE(randomBytes(8));
 }

--- a/src/message/decode.ts
+++ b/src/message/decode.ts
@@ -42,7 +42,7 @@ export function decode(data: Buffer): Message {
 }
 
 function decodePing(data: Buffer): IPingMessage {
-  const rlpRaw = RLP.decode(data.slice(1)) as unknown as Buffer[];
+  const rlpRaw = (RLP.decode(data.slice(1)) as unknown) as Buffer[];
   if (!Array.isArray(rlpRaw) || rlpRaw.length !== 2) {
     throw new Error(ERR_INVALID_MESSAGE);
   }
@@ -54,7 +54,7 @@ function decodePing(data: Buffer): IPingMessage {
 }
 
 function decodePong(data: Buffer): IPongMessage {
-  const rlpRaw = RLP.decode(data.slice(1)) as unknown as Buffer[];
+  const rlpRaw = (RLP.decode(data.slice(1)) as unknown) as Buffer[];
   if (!Array.isArray(rlpRaw) || rlpRaw.length !== 4) {
     throw new Error(ERR_INVALID_MESSAGE);
   }
@@ -68,7 +68,7 @@ function decodePong(data: Buffer): IPongMessage {
 }
 
 function decodeFindNode(data: Buffer): IFindNodeMessage {
-  const rlpRaw = RLP.decode(data.slice(1)) as unknown as Buffer[];
+  const rlpRaw = (RLP.decode(data.slice(1)) as unknown) as Buffer[];
   if (!Array.isArray(rlpRaw) || rlpRaw.length !== 2) {
     throw new Error(ERR_INVALID_MESSAGE);
   }
@@ -80,22 +80,20 @@ function decodeFindNode(data: Buffer): IFindNodeMessage {
 }
 
 function decodeNodes(data: Buffer): INodesMessage {
-  const rlpRaw = RLP.decode(data.slice(1)) as unknown as RLP.Decoded;
-  if (
-    !Array.isArray(rlpRaw) || rlpRaw.length !== 3 || !Array.isArray(rlpRaw[2])
-  ) {
+  const rlpRaw = (RLP.decode(data.slice(1)) as unknown) as RLP.Decoded;
+  if (!Array.isArray(rlpRaw) || rlpRaw.length !== 3 || !Array.isArray(rlpRaw[2])) {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
     type: MessageType.NODES,
     id: toBigIntBE(rlpRaw[0]),
     total: rlpRaw[1].length ? rlpRaw[1].readUIntBE(0, rlpRaw[1].length) : 0,
-    enrs: rlpRaw[2].map(enrRaw => ENR.decodeFromValues(enrRaw)),
+    enrs: rlpRaw[2].map((enrRaw) => ENR.decodeFromValues(enrRaw)),
   };
 }
 
 function decodeRegTopic(data: Buffer): IRegTopicMessage {
-  const rlpRaw = RLP.decode(data.slice(1)) as unknown as Buffer[];
+  const rlpRaw = (RLP.decode(data.slice(1)) as unknown) as Buffer[];
   if (!Array.isArray(rlpRaw) || rlpRaw.length !== 4 || !Array.isArray(rlpRaw[2])) {
     throw new Error(ERR_INVALID_MESSAGE);
   }
@@ -103,13 +101,13 @@ function decodeRegTopic(data: Buffer): IRegTopicMessage {
     type: MessageType.REGTOPIC,
     id: toBigIntBE(rlpRaw[0]),
     topic: rlpRaw[1],
-    enr: ENR.decodeFromValues(rlpRaw[2] as unknown as Buffer[]),
+    enr: ENR.decodeFromValues((rlpRaw[2] as unknown) as Buffer[]),
     ticket: rlpRaw[3],
   };
 }
 
 function decodeTicket(data: Buffer): ITicketMessage {
-  const rlpRaw = RLP.decode(data.slice(1)) as unknown as Buffer[];
+  const rlpRaw = (RLP.decode(data.slice(1)) as unknown) as Buffer[];
   if (!Array.isArray(rlpRaw) || rlpRaw.length !== 3) {
     throw new Error(ERR_INVALID_MESSAGE);
   }
@@ -122,7 +120,7 @@ function decodeTicket(data: Buffer): ITicketMessage {
 }
 
 function decodeRegConfirmation(data: Buffer): IRegConfirmationMessage {
-  const rlpRaw = RLP.decode(data.slice(1)) as unknown as Buffer[];
+  const rlpRaw = (RLP.decode(data.slice(1)) as unknown) as Buffer[];
   if (!Array.isArray(rlpRaw) || rlpRaw.length !== 2) {
     throw new Error(ERR_INVALID_MESSAGE);
   }
@@ -134,7 +132,7 @@ function decodeRegConfirmation(data: Buffer): IRegConfirmationMessage {
 }
 
 function decodeTopicQuery(data: Buffer): ITopicQueryMessage {
-  const rlpRaw = RLP.decode(data.slice(1)) as unknown as Buffer[];
+  const rlpRaw = (RLP.decode(data.slice(1)) as unknown) as Buffer[];
   if (!Array.isArray(rlpRaw) || rlpRaw.length !== 2) {
     throw new Error(ERR_INVALID_MESSAGE);
   }

--- a/src/message/encode.ts
+++ b/src/message/encode.ts
@@ -46,88 +46,43 @@ function toBuffer(n: bigint): Buffer {
 }
 
 export function encodePingMessage(m: IPingMessage): Buffer {
-  return Buffer.concat([
-    Buffer.from([MessageType.PING]),
-    RLP.encode([
-      toBuffer(m.id),
-      toBuffer(m.enrSeq),
-    ]),
-  ]);
+  return Buffer.concat([Buffer.from([MessageType.PING]), RLP.encode([toBuffer(m.id), toBuffer(m.enrSeq)])]);
 }
 
 export function encodePongMessage(m: IPongMessage): Buffer {
   const ipMultiaddr = Multiaddr(`/${isIp.v4(m.recipientIp) ? "ip4" : "ip6"}/${m.recipientIp}`);
   return Buffer.concat([
     Buffer.from([MessageType.PONG]),
-    RLP.encode([
-      toBuffer(m.id),
-      toBuffer(m.enrSeq),
-      ipMultiaddr.tuples()[0][1],
-      m.recipientPort,
-    ]),
+    RLP.encode([toBuffer(m.id), toBuffer(m.enrSeq), ipMultiaddr.tuples()[0][1], m.recipientPort]),
   ]);
 }
 
 export function encodeFindNodeMessage(m: IFindNodeMessage): Buffer {
-  return Buffer.concat([
-    Buffer.from([MessageType.FINDNODE]),
-    RLP.encode([
-      toBuffer(m.id),
-      m.distance,
-    ]),
-  ]);
+  return Buffer.concat([Buffer.from([MessageType.FINDNODE]), RLP.encode([toBuffer(m.id), m.distance])]);
 }
 
 export function encodeNodesMessage(m: INodesMessage): Buffer {
   return Buffer.concat([
     Buffer.from([MessageType.NODES]),
-    RLP.encode([
-      toBuffer(m.id),
-      m.total,
-      m.enrs.map(enr => enr.encodeToValues()),
-    ]),
+    RLP.encode([toBuffer(m.id), m.total, m.enrs.map((enr) => enr.encodeToValues())]),
   ]);
 }
 
 export function encodeRegTopicMessage(m: IRegTopicMessage): Buffer {
   return Buffer.concat([
     Buffer.from([MessageType.REGTOPIC]),
-    RLP.encode([
-      toBuffer(m.id),
-      m.topic,
-      m.enr.encodeToValues(),
-      m.ticket,
-    ]),
+    RLP.encode([toBuffer(m.id), m.topic, m.enr.encodeToValues(), m.ticket]),
   ]);
 }
 
 export function encodeTicketMessage(m: ITicketMessage): Buffer {
-  return Buffer.concat([
-    Buffer.from([MessageType.TICKET]),
-    RLP.encode([
-      toBuffer(m.id),
-      m.ticket,
-      m.waitTime,
-    ]),
-  ]);
+  return Buffer.concat([Buffer.from([MessageType.TICKET]), RLP.encode([toBuffer(m.id), m.ticket, m.waitTime])]);
 }
 
 export function encodeRegConfirmMessage(m: IRegConfirmationMessage): Buffer {
-  return Buffer.concat([
-    Buffer.from([MessageType.REGCONFIRMATION]),
-    RLP.encode([
-      toBuffer(m.id),
-      m.topic,
-    ]),
-  ]);
+  return Buffer.concat([Buffer.from([MessageType.REGCONFIRMATION]), RLP.encode([toBuffer(m.id), m.topic])]);
 }
 
 export function encodeTopicQueryMessage(m: ITopicQueryMessage): Buffer {
-  return Buffer.concat([
-    Buffer.from([MessageType.TOPICQUERY]),
-    RLP.encode([
-      toBuffer(m.id),
-      m.topic,
-    ]),
-  ]);
+  return Buffer.concat([Buffer.from([MessageType.TOPICQUERY]), RLP.encode([toBuffer(m.id), m.topic])]);
 }

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -15,17 +15,9 @@ export enum MessageType {
 
 export type Message = RequestMessage | ResponseMessage;
 
-export type RequestMessage =
-  IPingMessage |
-  IFindNodeMessage |
-  IRegTopicMessage |
-  ITopicQueryMessage;
+export type RequestMessage = IPingMessage | IFindNodeMessage | IRegTopicMessage | ITopicQueryMessage;
 
-export type ResponseMessage =
-  IPongMessage |
-  INodesMessage |
-  ITicketMessage |
-  IRegConfirmationMessage;
+export type ResponseMessage = IPongMessage | INodesMessage | ITicketMessage | IRegConfirmationMessage;
 
 export interface IPingMessage {
   type: MessageType.PING;

--- a/src/packet/constants.ts
+++ b/src/packet/constants.ts
@@ -20,4 +20,3 @@ export const ERR_TOO_SMALL = "packet too small";
 export const ERR_TOO_LARGE = "packet too large";
 export const ERR_UNKNOWN_FORMAT = "unknown format";
 export const ERR_INVALID_BYTE_SIZE = "invalid byte size";
-

--- a/src/packet/create.ts
+++ b/src/packet/create.ts
@@ -19,11 +19,7 @@ export function createMagic(nodeId: NodeId): Buffer {
   return sha256.digest(Buffer.concat([fromHex(nodeId), Buffer.from(WHOAREYOU_STRING, "utf-8")]));
 }
 
-export function createWhoAreYouPacket(
-  nodeId: NodeId,
-  authTag: AuthTag,
-  enrSeq: SequenceNumber
-): IWhoAreYouPacket {
+export function createWhoAreYouPacket(nodeId: NodeId, authTag: AuthTag, enrSeq: SequenceNumber): IWhoAreYouPacket {
   return {
     type: PacketType.WhoAreYou,
     magic: createMagic(nodeId),

--- a/src/packet/decode.ts
+++ b/src/packet/decode.ts
@@ -38,7 +38,7 @@ export function decode(data: Buffer, magic: Magic): Packet {
   }
   const tag = data.slice(0, TAG_LENGTH);
   data = data.slice(TAG_LENGTH);
-  const decoded = RLP.decode(data, true) as unknown as RLP.Decoded;
+  const decoded = (RLP.decode(data, true) as unknown) as RLP.Decoded;
   // data looks like either:
   //   magic ++ rlp_list(...)
   //   tag   ++ rlp_bytes(...) ++ message
@@ -57,10 +57,7 @@ export function decodeWhoAreYou(magic: Magic, data: Buffer[], remainder: Buffer)
     throw new Error(ERR_UNKNOWN_FORMAT);
   }
   const [token, idNonce, enrSeqBytes] = data;
-  if (
-    idNonce.length !== ID_NONCE_LENGTH ||
-    token.length !== AUTH_TAG_LENGTH
-  ) {
+  if (idNonce.length !== ID_NONCE_LENGTH || token.length !== AUTH_TAG_LENGTH) {
     throw new Error(ERR_INVALID_BYTE_SIZE);
   }
   const enrSeq = enrSeqBytes.length ? Number(`0x${enrSeqBytes.toString("hex")}`) : 0;
@@ -87,13 +84,7 @@ export function decodeAuthHeader(tag: Tag, data: Buffer[], remainder: Buffer): I
   if (!Array.isArray(data) || data.length !== 5) {
     throw new Error(ERR_UNKNOWN_FORMAT);
   }
-  const [
-    authTag,
-    idNonce,
-    authSchemeNameBytes,
-    ephemeralPubkey,
-    authResponse,
-  ] = data;
+  const [authTag, idNonce, authSchemeNameBytes, ephemeralPubkey, authResponse] = data;
   return {
     type: PacketType.AuthMessage,
     tag,
@@ -109,12 +100,8 @@ export function decodeAuthHeader(tag: Tag, data: Buffer[], remainder: Buffer): I
 }
 
 export function decodeAuthResponse(data: Buffer): IAuthResponse {
-  const responseRaw = RLP.decode(data) as unknown as RLP.Decoded;
-  if (
-    !Array.isArray(responseRaw) ||
-    responseRaw.length !== 3 ||
-    !Array.isArray(responseRaw[2])
-  ) {
+  const responseRaw = (RLP.decode(data) as unknown) as RLP.Decoded;
+  if (!Array.isArray(responseRaw) || responseRaw.length !== 3 || !Array.isArray(responseRaw[2])) {
     throw new Error(ERR_UNKNOWN_FORMAT);
   }
   const response: IAuthResponse = {

--- a/src/packet/encode.ts
+++ b/src/packet/encode.ts
@@ -22,46 +22,25 @@ export function encode(packet: Packet): Buffer {
 }
 
 export function encodeAuthHeader(h: IAuthHeader): Buffer {
-  return RLP.encode([
-    h.authTag,
-    h.idNonce,
-    h.authSchemeName,
-    h.ephemeralPubkey,
-    h.authResponse,
-  ]);
+  return RLP.encode([h.authTag, h.idNonce, h.authSchemeName, h.ephemeralPubkey, h.authResponse]);
 }
 
 function encodeWhoAreYouPacket(p: IWhoAreYouPacket): Buffer {
-  return Buffer.concat([
-    p.magic,
-    RLP.encode([
-      p.token,
-      p.idNonce,
-      p.enrSeq,
-    ]),
-  ]);
+  return Buffer.concat([p.magic, RLP.encode([p.token, p.idNonce, p.enrSeq])]);
 }
 
 function encodeAuthMessagePacket(p: IAuthMessagePacket): Buffer {
-  return Buffer.concat([
-    p.tag,
-    encodeAuthHeader(p.authHeader),
-    p.message,
-  ]);
+  return Buffer.concat([p.tag, encodeAuthHeader(p.authHeader), p.message]);
 }
 
 function encodeMessagePacket(p: IMessagePacket): Buffer {
-  return Buffer.concat([
-    p.tag,
-    RLP.encode(p.authTag),
-    p.message,
-  ]);
+  return Buffer.concat([p.tag, RLP.encode(p.authTag), p.message]);
 }
 
 export function encodeAuthResponse(authResponse: IAuthResponse, privateKey: Buffer): Buffer {
   return RLP.encode([
     authResponse.version,
     authResponse.signature,
-    authResponse.nodeRecord ? authResponse.nodeRecord.encodeToValues(privateKey) : []
+    authResponse.nodeRecord ? authResponse.nodeRecord.encodeToValues(privateKey) : [],
   ]);
 }

--- a/src/service/addrVotes.ts
+++ b/src/service/addrVotes.ts
@@ -52,7 +52,7 @@ export class AddrVotes {
     const tiebreakerStr = tiebreaker.toString();
     let best: [string, number] = [tiebreakerStr, this.tallies[tiebreakerStr]];
     for (const [addrStr, total] of Object.entries(this.tallies)) {
-      if (total >  best[1]) {
+      if (total > best[1]) {
         best = [addrStr, total];
       }
     }

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -5,7 +5,14 @@ import Multiaddr = require("multiaddr");
 
 import { ITransportService } from "../transport";
 import {
-  PacketType, Packet, IWhoAreYouPacket, IAuthMessagePacket, IMessagePacket, AuthTag, createTag, createSrcId,
+  PacketType,
+  Packet,
+  IWhoAreYouPacket,
+  IAuthMessagePacket,
+  IMessagePacket,
+  AuthTag,
+  createTag,
+  createSrcId,
 } from "../packet";
 import { ENR, NodeId } from "../enr";
 import { Session } from "./session";
@@ -34,7 +41,7 @@ const log = debug("discv5:sessionService");
  * to match the source, the `Session` is promoted to an established state. RPC requests are not sent
  * to untrusted Sessions, only responses.
  */
-export class SessionService extends (EventEmitter as { new(): StrictEventEmitter<EventEmitter, ISessionEvents> }) {
+export class SessionService extends (EventEmitter as { new (): StrictEventEmitter<EventEmitter, ISessionEvents> }) {
   /**
    * The local ENR
    */
@@ -208,18 +215,19 @@ export class SessionService extends (EventEmitter as { new(): StrictEventEmitter
       log(
         "Received a WHOAREYOU packet that references an unknown or expired request. source: %s, token: %s",
         src,
-        packet.token.toString("hex"),
+        packet.token.toString("hex")
       );
       return;
     }
     const request = Array.from(pendingRequests.values()).find((r) =>
-      packet.token.equals((r.packet as IMessagePacket).authTag || Buffer.alloc(0)));
+      packet.token.equals((r.packet as IMessagePacket).authTag || Buffer.alloc(0))
+    );
     if (!request) {
       // Received a WHOAREYOU packet that references an unknown or expired request.
       log(
         "Received a WHOAREYOU packet that references an unknown or expired request. source: %s, token: %s",
         src,
-        packet.token.toString("hex"),
+        packet.token.toString("hex")
       );
       return;
     }
@@ -328,8 +336,8 @@ export class SessionService extends (EventEmitter as { new(): StrictEventEmitter
       log("Received an authenticated header without a matching WHOAREYOU request, dropping.");
       return;
     }
-    const request = Array.from(pendingRequests.values()).find((r) =>
-      r.packet.type === PacketType.WhoAreYou && r.dstId === srcId
+    const request = Array.from(pendingRequests.values()).find(
+      (r) => r.packet.type === PacketType.WhoAreYou && r.dstId === srcId
     );
     if (!request) {
       log("Received an authenticated header without a matching WHOAREYOU request, dropping.");
@@ -347,13 +355,7 @@ export class SessionService extends (EventEmitter as { new(): StrictEventEmitter
 
     // establish the session
     try {
-      const trusted = session.establishFromHeader(
-        this.keypair,
-        this.enr.nodeId,
-        srcId,
-        idNonce,
-        packet.authHeader
-      );
+      const trusted = session.establishFromHeader(this.keypair, this.enr.nodeId, srcId, idNonce, packet.authHeader);
       if (trusted) {
         log("Session established with node from header: %s", srcId);
         // session is trusted, notify the protocol
@@ -373,15 +375,12 @@ export class SessionService extends (EventEmitter as { new(): StrictEventEmitter
     this.sessions.setTimeout(srcId, SESSION_TIMEOUT);
 
     // decrypt the message
-    this.onMessage(
-      src,
-      {
-        type: PacketType.Message,
-        authTag: packet.authHeader.authTag,
-        message: packet.message,
-        tag: packet.tag,
-      }
-    );
+    this.onMessage(src, {
+      type: PacketType.Message,
+      authTag: packet.authHeader.authTag,
+      message: packet.message,
+      tag: packet.tag,
+    });
   }
 
   public onMessage(src: Multiaddr, packet: IMessagePacket): void {
@@ -529,8 +528,7 @@ export class SessionService extends (EventEmitter as { new(): StrictEventEmitter
         const pendingMessages = this.pendingMessages.get(dstId);
         if (pendingMessages) {
           this.pendingMessages.delete(dstId);
-          pendingMessages.forEach((message) =>
-            this.emit("requestFailed", request.dstId, message.id));
+          pendingMessages.forEach((message) => this.emit("requestFailed", request.dstId, message.id));
         }
         // drop the session
         this.sessions.delete(dstId);
@@ -566,8 +564,7 @@ export class SessionService extends (EventEmitter as { new(): StrictEventEmitter
     }
     // No pending requests for nodeId
     // Fail all pending messages for this node
-    (this.pendingMessages.get(nodeId) || [])
-      .forEach((message) => this.emit("requestFailed", nodeId, message.id));
+    (this.pendingMessages.get(nodeId) || []).forEach((message) => this.emit("requestFailed", nodeId, message.id));
     this.pendingMessages.delete(nodeId);
     log("Session timed out for node: %s", nodeId);
   };

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -48,12 +48,12 @@ export interface IKeys {
  * We maintain 0, 1, or 2 keys depending on the state
  */
 export type ISessionState =
-  {state: SessionState.WhoAreYouSent} |
-  {state: SessionState.RandomSent} |
-  {state: SessionState.Poisoned} |
-  {state: SessionState.AwaitingResponse; currentKeys: IKeys} |
-  {state: SessionState.Established; currentKeys: IKeys} |
-  {state: SessionState.EstablishedAwaitingResponse; currentKeys: IKeys; newKeys: IKeys};
+  | { state: SessionState.WhoAreYouSent }
+  | { state: SessionState.RandomSent }
+  | { state: SessionState.Poisoned }
+  | { state: SessionState.AwaitingResponse; currentKeys: IKeys }
+  | { state: SessionState.Established; currentKeys: IKeys }
+  | { state: SessionState.EstablishedAwaitingResponse; currentKeys: IKeys; newKeys: IKeys };
 
 export enum TrustedState {
   /**

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -2,9 +2,7 @@ import { EventEmitter } from "events";
 import StrictEventEmitter from "strict-event-emitter-types";
 import Multiaddr = require("multiaddr");
 
-import {
-  Packet,
-} from "../packet";
+import { Packet } from "../packet";
 
 export interface ISocketAddr {
   port: number;

--- a/src/transport/udp.ts
+++ b/src/transport/udp.ts
@@ -2,26 +2,14 @@ import * as dgram from "dgram";
 import { EventEmitter } from "events";
 import Multiaddr = require("multiaddr");
 
-import {
-  decode,
-  encode,
-  Packet,
-  MAX_PACKET_SIZE,
-} from "../packet";
-import {
-  IRemoteInfo,
-  ITransportService,
-  TransportEventEmitter,
-} from "./types";
-
+import { decode, encode, Packet, MAX_PACKET_SIZE } from "../packet";
+import { IRemoteInfo, ITransportService, TransportEventEmitter } from "./types";
 
 /**
  * This class is responsible for encoding outgoing Packets and decoding incoming Packets over UDP
  */
-export class UDPTransportService
-  extends (EventEmitter as { new(): TransportEventEmitter })
+export class UDPTransportService extends (EventEmitter as { new (): TransportEventEmitter })
   implements ITransportService {
-
   public multiaddr: Multiaddr;
   private socket!: dgram.Socket;
   private whoAreYouMagic: Buffer;
@@ -54,20 +42,11 @@ export class UDPTransportService
 
   public async send(to: Multiaddr, packet: Packet): Promise<void> {
     const nodeAddr = to.toOptions();
-    return new Promise((resolve) =>
-      this.socket.send(
-        encode(packet),
-        nodeAddr.port,
-        nodeAddr.host,
-        () => resolve()
-      )
-    );
+    return new Promise((resolve) => this.socket.send(encode(packet), nodeAddr.port, nodeAddr.host, () => resolve()));
   }
 
   public handleIncoming = (data: Buffer, rinfo: IRemoteInfo): void => {
-    const multiaddr = Multiaddr(
-      `/${rinfo.family === "IPv4" ? "ip4" : "ip6"}/${rinfo.address}/udp/${rinfo.port}`
-    );
+    const multiaddr = Multiaddr(`/${rinfo.family === "IPv4" ? "ip4" : "ip6"}/${rinfo.address}/udp/${rinfo.port}`);
     try {
       const packet = decode(data, this.whoAreYouMagic);
       this.emit("packet", multiaddr, packet);

--- a/test/enr.test.ts
+++ b/test/enr.test.ts
@@ -27,7 +27,8 @@ describe("ENR", () => {
   });
 
   it("should encode/decode to text encoding", () => {
-    const testTxt = "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+    const testTxt =
+      "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
     const decoded = ENR.decodeTxt(testTxt);
     expect(decoded).to.deep.equal(record);
     expect(record.encodeTxt(privateKey)).to.equal(testTxt);

--- a/test/enr/enr.test.ts
+++ b/test/enr/enr.test.ts
@@ -1,14 +1,14 @@
 import PeerId from "peer-id";
-import {expect, assert} from "chai";
+import { expect, assert } from "chai";
 import { ENR } from "../../src/enr/enr";
 import { createKeypairFromPeerId } from "../../src/keypair";
 import { toHex } from "../../src/util";
 import { ERR_INVALID_ID } from "../../src/enr/constants";
 
-describe("ENR", function() {
+describe("ENR", function () {
   describe("decodeTxt", () => {
     it("should encodeTxt and decodeTxt", async () => {
-      const peerId = await PeerId.create({keyType: "secp256k1"});
+      const peerId = await PeerId.create({ keyType: "secp256k1" });
       const enr = ENR.createFromPeerId(peerId);
       const keypair = createKeypairFromPeerId(peerId);
       const txt = enr.encodeTxt(keypair.privateKey);
@@ -18,7 +18,8 @@ describe("ENR", function() {
     });
 
     it("should decode valid enr successfully", () => {
-      const txt = "enr:-Ku4QMh15cIjmnq-co5S3tYaNXxDzKTgj0ufusA-QfZ66EWHNsULt2kb0eTHoo1Dkjvvf6CAHDS1Di-htjiPFZzaIPcLh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD2d10HAAABE________x8AgmlkgnY0gmlwhHZFkMSJc2VjcDI1NmsxoQIWSDEWdHwdEA3Lw2B_byeFQOINTZ0GdtF9DBjes6JqtIN1ZHCCIyg";
+      const txt =
+        "enr:-Ku4QMh15cIjmnq-co5S3tYaNXxDzKTgj0ufusA-QfZ66EWHNsULt2kb0eTHoo1Dkjvvf6CAHDS1Di-htjiPFZzaIPcLh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD2d10HAAABE________x8AgmlkgnY0gmlwhHZFkMSJc2VjcDI1NmsxoQIWSDEWdHwdEA3Lw2B_byeFQOINTZ0GdtF9DBjes6JqtIN1ZHCCIyg";
       const enr = ENR.decodeTxt(txt);
       const eth2 = enr.get("eth2") as Buffer;
       expect(eth2).to.not.be.undefined;
@@ -27,7 +28,10 @@ describe("ENR", function() {
 
     it("should throw error - no id", () => {
       try {
-        const txt = Buffer.from('656e723a2d435972595a62404b574342526c4179357a7a61445a584a42476b636e68344d486342465a6e75584e467264764a6a5830346a527a6a7a', 'hex').toString();
+        const txt = Buffer.from(
+          "656e723a2d435972595a62404b574342526c4179357a7a61445a584a42476b636e68344d486342465a6e75584e467264764a6a5830346a527a6a7a",
+          "hex"
+        ).toString();
         ENR.decodeTxt(txt);
         assert.fail("Expect error here");
       } catch (err) {
@@ -37,11 +41,12 @@ describe("ENR", function() {
 
     it("should throw error - no public key", () => {
       try {
-        const txt = "enr:-IS4QJ2d11eu6dC7E7LoXeLMgMP3kom1u3SE8esFSWvaHoo0dP1jg8O3-nx9ht-EO3CmG7L6OkHcMmoIh00IYWB92QABgmlkgnY0gmlwhH8AAAGJc2d11eu6dCsxoQIB_c-jQMOXsbjWkbN-kj99H57gfId5pfb4wa1qxwV4CIN1ZHCCIyk";
+        const txt =
+          "enr:-IS4QJ2d11eu6dC7E7LoXeLMgMP3kom1u3SE8esFSWvaHoo0dP1jg8O3-nx9ht-EO3CmG7L6OkHcMmoIh00IYWB92QABgmlkgnY0gmlwhH8AAAGJc2d11eu6dCsxoQIB_c-jQMOXsbjWkbN-kj99H57gfId5pfb4wa1qxwV4CIN1ZHCCIyk";
         ENR.decodeTxt(txt);
         assert.fail("Expect error here");
       } catch (err) {
-        expect(err.message).to.be.equal("Failed to verify enr: No public key")
+        expect(err.message).to.be.equal("Failed to verify enr: No public key");
       }
     });
   });
@@ -59,7 +64,7 @@ describe("ENR", function() {
 
     it("should throw error - invalid id", () => {
       try {
-        const enr = new ENR({"id": Buffer.from("v3")}, BigInt(0), Buffer.alloc(0));
+        const enr = new ENR({ id: Buffer.from("v3") }, BigInt(0), Buffer.alloc(0));
         enr.verify(Buffer.alloc(0), Buffer.alloc(0));
         assert.fail("Expect error here");
       } catch (err) {
@@ -69,7 +74,7 @@ describe("ENR", function() {
 
     it("should throw error - no public key", () => {
       try {
-        const enr = new ENR({"id": Buffer.from("v4")}, BigInt(0), Buffer.alloc(0));
+        const enr = new ENR({ id: Buffer.from("v4") }, BigInt(0), Buffer.alloc(0));
         enr.verify(Buffer.alloc(0), Buffer.alloc(0));
         assert.fail("Expect error here");
       } catch (err) {
@@ -78,7 +83,8 @@ describe("ENR", function() {
     });
 
     it("should return false", () => {
-      const txt = "enr:-Ku4QMh15cIjmnq-co5S3tYaNXxDzKTgj0ufusA-QfZ66EWHNsULt2kb0eTHoo1Dkjvvf6CAHDS1Di-htjiPFZzaIPcLh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD2d10HAAABE________x8AgmlkgnY0gmlwhHZFkMSJc2VjcDI1NmsxoQIWSDEWdHwdEA3Lw2B_byeFQOINTZ0GdtF9DBjes6JqtIN1ZHCCIyg";
+      const txt =
+        "enr:-Ku4QMh15cIjmnq-co5S3tYaNXxDzKTgj0ufusA-QfZ66EWHNsULt2kb0eTHoo1Dkjvvf6CAHDS1Di-htjiPFZzaIPcLh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD2d10HAAABE________x8AgmlkgnY0gmlwhHZFkMSJc2VjcDI1NmsxoQIWSDEWdHwdEA3Lw2B_byeFQOINTZ0GdtF9DBjes6JqtIN1ZHCCIyg";
       const enr = ENR.decodeTxt(txt);
       // should have id and public key inside ENR
       expect(enr.verify(Buffer.alloc(0), Buffer.alloc(0))).to.be.false;

--- a/test/kademlia/kademlia.test.ts
+++ b/test/kademlia/kademlia.test.ts
@@ -3,7 +3,7 @@ import { KademliaRoutingTable } from "../../src/kademlia/kademlia";
 import { expect } from "chai";
 import { ENR, v4, createNodeId } from "../../src/enr";
 
-describe("Kademlia routing table",  () => {
+describe("Kademlia routing table", () => {
   const nodeId = createNodeId(Buffer.alloc(32));
   it("should throw an error if the number of buckets is zero or negative", () => {
     expect(() => new KademliaRoutingTable(nodeId, 0)).throw("k must be positive");

--- a/test/message/codec.test.ts
+++ b/test/message/codec.test.ts
@@ -56,19 +56,25 @@ describe("message", () => {
         id: 1n,
         total: 1,
         enrs: [
-          ENR.decodeTxt("enr:-HW4QBzimRxkmT18hMKaAL3IcZF1UcfTMPyi3Q1pxwZZbcZVRI8DC5infUAB_UauARLOJtYTxaagKoGmIjzQxO2qUygBgmlkgnY0iXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAPMljNMTg"),
-          ENR.decodeTxt("enr:-HW4QNfxw543Ypf4HXKXdYxkyzfcxcO-6p9X986WldfVpnVTQX1xlTnWrktEWUbeTZnmgOuAY_KUhbVV1Ft98WoYUBMBgmlkgnY0iXNlY3AyNTZrMaEDDiy3QkHAxPyOgWbxp5oF1bDdlYE6dLCUUp8xfVw50jU"),
+          ENR.decodeTxt(
+            "enr:-HW4QBzimRxkmT18hMKaAL3IcZF1UcfTMPyi3Q1pxwZZbcZVRI8DC5infUAB_UauARLOJtYTxaagKoGmIjzQxO2qUygBgmlkgnY0iXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAPMljNMTg"
+          ),
+          ENR.decodeTxt(
+            "enr:-HW4QNfxw543Ypf4HXKXdYxkyzfcxcO-6p9X986WldfVpnVTQX1xlTnWrktEWUbeTZnmgOuAY_KUhbVV1Ft98WoYUBMBgmlkgnY0iXNlY3AyNTZrMaEDDiy3QkHAxPyOgWbxp5oF1bDdlYE6dLCUUp8xfVw50jU"
+          ),
         ],
       },
-      expected: Buffer.from("04f8f20101f8eef875b8401ce2991c64993d7c84c29a00bdc871917551c7d330fca2dd0d69c706596dc655448f030b98a77d4001fd46ae0112ce26d613c5a6a02a81a6223cd0c4edaa53280182696482763489736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138f875b840d7f1c39e376297f81d7297758c64cb37dcc5c3beea9f57f7ce9695d7d5a67553417d719539d6ae4b445946de4d99e680eb8063f29485b555d45b7df16a1850130182696482763489736563703235366b31a1030e2cb74241c0c4fc8e8166f1a79a05d5b0dd95813a74b094529f317d5c39d235", "hex"),
+      expected: Buffer.from(
+        "04f8f20101f8eef875b8401ce2991c64993d7c84c29a00bdc871917551c7d330fca2dd0d69c706596dc655448f030b98a77d4001fd46ae0112ce26d613c5a6a02a81a6223cd0c4edaa53280182696482763489736563703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138f875b840d7f1c39e376297f81d7297758c64cb37dcc5c3beea9f57f7ce9695d7d5a67553417d719539d6ae4b445946de4d99e680eb8063f29485b555d45b7df16a1850130182696482763489736563703235366b31a1030e2cb74241c0c4fc8e8166f1a79a05d5b0dd95813a74b094529f317d5c39d235",
+        "hex"
+      ),
     },
   ];
-  for (const {message, expected} of testCases) {
+  for (const { message, expected } of testCases) {
     it(`should encode/decode message type ${MessageType[message.type]}`, () => {
       const actual = encode(message);
       // expect(actual).to.deep.equal(expected);
       expect(decode(actual)).to.deep.equal(message);
     });
   }
-
 });

--- a/test/packet/codec.test.ts
+++ b/test/packet/codec.test.ts
@@ -1,29 +1,27 @@
 /* eslint-env mocha */
 /* eslint-disable max-len */
-import {expect} from "chai";
-import {
-  decode,
-  encode,
-  IAuthMessagePacket,
-  IWhoAreYouPacket,
-  PacketType,
-  IMessagePacket,
-} from "../../src/packet";
-
+import { expect } from "chai";
+import { decode, encode, IAuthMessagePacket, IWhoAreYouPacket, PacketType, IMessagePacket } from "../../src/packet";
 
 describe("Packet - known test vectors", () => {
   it("should correctly encode/decode random IMessagePacket", () => {
     const magic = Buffer.from("1101010101010101010101010101010101010101010101010101010101010101", "hex");
     const tag = Buffer.from("0101010101010101010101010101010101010101010101010101010101010101", "hex");
     const authTag = Buffer.from("020202020202020202020202", "hex");
-    const message = Buffer.from("0404040404040404040404040404040404040404040404040404040404040404040404040404040404040404", "hex");
+    const message = Buffer.from(
+      "0404040404040404040404040404040404040404040404040404040404040404040404040404040404040404",
+      "hex"
+    );
     const p0: IMessagePacket = {
       type: PacketType.Message,
       tag,
       authTag,
       message,
     };
-    const expected = Buffer.from("01010101010101010101010101010101010101010101010101010101010101018c0202020202020202020202020404040404040404040404040404040404040404040404040404040404040404040404040404040404040404", "hex");
+    const expected = Buffer.from(
+      "01010101010101010101010101010101010101010101010101010101010101018c0202020202020202020202020404040404040404040404040404040404040404040404040404040404040404040404040404040404040404",
+      "hex"
+    );
     const b0 = encode(p0);
     expect(b0).to.deep.equal(expected);
     const p1 = decode(b0, magic);
@@ -42,7 +40,10 @@ describe("Packet - known test vectors", () => {
       idNonce,
       enrSeq,
     };
-    const expected = Buffer.from("0101010101010101010101010101010101010101010101010101010101010101ef8c020202020202020202020202a0030303030303030303030303030303030303030303030303030303030303030301", "hex");
+    const expected = Buffer.from(
+      "0101010101010101010101010101010101010101010101010101010101010101ef8c020202020202020202020202a0030303030303030303030303030303030303030303030303030303030303030301",
+      "hex"
+    );
     const b0 = encode(p0);
     expect(b0).to.deep.equal(expected);
     const p1 = decode(b0, magic);
@@ -54,8 +55,14 @@ describe("Packet - known test vectors", () => {
     const tag = Buffer.from("93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903", "hex");
     const authTag = Buffer.from("27b5af763c446acd2749fe8e", "hex");
     const idNonce = Buffer.from("e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c65", "hex");
-    const ephemeralPubkey = Buffer.from("b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81", "hex");
-    const authResponse = Buffer.from("570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852", "hex");
+    const ephemeralPubkey = Buffer.from(
+      "b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81",
+      "hex"
+    );
+    const authResponse = Buffer.from(
+      "570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852",
+      "hex"
+    );
     const message = Buffer.from("a5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
     const p0: IAuthMessagePacket = {
       type: PacketType.AuthMessage,
@@ -69,7 +76,10 @@ describe("Packet - known test vectors", () => {
       },
       message,
     };
-    const expected = Buffer.from("93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903f8cc8c27b5af763c446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c658367636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852a5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
+    const expected = Buffer.from(
+      "93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903f8cc8c27b5af763c446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c658367636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852a5d12a2d94b8ccb3ba55558229867dc13bfa3648",
+      "hex"
+    );
     const b0 = encode(p0);
     expect(b0).to.deep.equal(expected);
     const p1 = decode(b0, magic);
@@ -87,7 +97,10 @@ describe("Packet - known test vectors", () => {
       authTag,
       message,
     };
-    const expected = Buffer.from("93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f421079038c27b5af763c446acd2749fe8ea5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
+    const expected = Buffer.from(
+      "93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f421079038c27b5af763c446acd2749fe8ea5d12a2d94b8ccb3ba55558229867dc13bfa3648",
+      "hex"
+    );
     const b0 = encode(p0);
     expect(b0).to.deep.equal(expected);
     const p1 = decode(b0, magic);

--- a/test/service/service.test.ts
+++ b/test/service/service.test.ts
@@ -27,8 +27,7 @@ describe("Discv5", async () => {
     await service0.stop();
   });
 
-  it("should start and stop", async () => {
-  });
+  it("should start and stop", async () => {});
 
   it("should allow to pick a port and network interface as a multiaddr", async () => {
     expect(service0.bindAddress.toString()).eq(mu0.toString());
@@ -52,7 +51,7 @@ describe("Discv5", async () => {
     enr1.encode(kp1.privateKey);
     const service1 = Discv5.create(enr1, peerId1, mu1);
     await service1.start();
-    for (let i =0; i < 100; i++) {
+    for (let i = 0; i < 100; i++) {
       const kp = generateKeypair(KeypairType.secp256k1);
       const enr = ENR.createV4(kp.publicKey);
       enr.encode(kp.privateKey);

--- a/test/session/crypto.test.ts
+++ b/test/session/crypto.test.ts
@@ -1,23 +1,39 @@
 /* eslint-env mocha */
-import {expect} from "chai";
+import { expect } from "chai";
 import secp256k1 = require("bcrypto/lib/secp256k1");
-import {randomBytes} from "bcrypto/lib/random";
+import { randomBytes } from "bcrypto/lib/random";
 
 import {
-  IKeys, deriveKey, generateSessionKeys, deriveKeysFromPubkey, signNonce,
-  verifyNonce, encryptMessage, decryptMessage, encryptAuthResponse, decryptAuthHeader,
+  IKeys,
+  deriveKey,
+  generateSessionKeys,
+  deriveKeysFromPubkey,
+  signNonce,
+  verifyNonce,
+  encryptMessage,
+  decryptMessage,
+  encryptAuthResponse,
+  decryptAuthHeader,
 } from "../../src/session";
 import { v4, ENR } from "../../src/enr";
 import { KeypairType, createKeypair } from "../../src/keypair";
 import {
-  encodeAuthResponse, createAuthResponse, createAuthHeader, encodeAuthHeader, encode, PacketType,
+  encodeAuthResponse,
+  createAuthResponse,
+  createAuthHeader,
+  encodeAuthHeader,
+  encode,
+  PacketType,
 } from "../../src/packet";
 
 describe("session crypto", () => {
   it("ecdh should produce expected secret", () => {
     const expected = Buffer.from("033b11a2a1f214567e1537ce5e509ffd9b21373247f2a3ff6841f4976f53165e7e", "hex");
 
-    const remotePK = Buffer.from("049961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157", "hex").slice(0, 65);
+    const remotePK = Buffer.from(
+      "049961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157",
+      "hex"
+    ).slice(0, 65);
     const localSK = Buffer.from("fb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736", "hex");
 
     expect(secp256k1.derive(remotePK, localSK)).to.deep.equal(expected);
@@ -59,15 +75,22 @@ describe("session crypto", () => {
   });
 
   it("signature of nonce should match expected value", () => {
-    const expected = Buffer.from("c5036e702a79902ad8aa147dabfe3958b523fd6fa36cc78e2889b912d682d8d35fdea142e141f690736d86f50b39746ba2d2fc510b46f82ee08f08fd55d133a4", "hex");
+    const expected = Buffer.from(
+      "c5036e702a79902ad8aa147dabfe3958b523fd6fa36cc78e2889b912d682d8d35fdea142e141f690736d86f50b39746ba2d2fc510b46f82ee08f08fd55d133a4",
+      "hex"
+    );
 
     const nonce = Buffer.from("a77e3aa0c144ae7c0a3af73692b7d6e5b7a2fdc0eda16e8d5e6cb0d08e88dd04", "hex");
-    const ephemPK = Buffer.from("9961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157", "hex");
+    const ephemPK = Buffer.from(
+      "9961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157",
+      "hex"
+    );
     const localSK = Buffer.from("fb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736", "hex");
 
     const actual = signNonce(createKeypair(KeypairType.secp256k1, localSK), nonce, ephemPK);
     expect(actual).to.deep.equal(expected);
-    expect(verifyNonce(createKeypair(KeypairType.secp256k1, undefined, v4.publicKey(localSK)), nonce, ephemPK, actual)).to.be.true;
+    expect(verifyNonce(createKeypair(KeypairType.secp256k1, undefined, v4.publicKey(localSK)), nonce, ephemPK, actual))
+      .to.be.true;
   });
 
   it("encrypted data should match expected", () => {
@@ -96,62 +119,54 @@ describe("session crypto", () => {
     const key = Buffer.from("7e8107fe766b6d357205280acf65c24275129ca9e44c0fd00144ca50024a1ce7", "hex");
     const kpriv = createKeypair(KeypairType.secp256k1, key);
     const idNonce = Buffer.from("e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c65", "hex");
-    const ephemPK = Buffer.from("b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81", "hex");
+    const ephemPK = Buffer.from(
+      "b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81",
+      "hex"
+    );
 
-    const expectedAuthPt = Buffer.from("f84405b840f753ac31b017536bacd0d0238a1f849e741aef03b7ad5db1d4e64d7aa80689931f21e590edcf80ee32bb2f30707fec88fb62ea8fbcd65b9272e9a0175fea976bc0", "hex");
+    const expectedAuthPt = Buffer.from(
+      "f84405b840f753ac31b017536bacd0d0238a1f849e741aef03b7ad5db1d4e64d7aa80689931f21e590edcf80ee32bb2f30707fec88fb62ea8fbcd65b9272e9a0175fea976bc0",
+      "hex"
+    );
 
     const authResp = createAuthResponse(signNonce(kpriv, idNonce, ephemPK));
 
-    expect(
-      encodeAuthResponse(authResp, key)
-    ).to.deep.equal(
-      expectedAuthPt
-    );
+    expect(encodeAuthResponse(authResp, key)).to.deep.equal(expectedAuthPt);
 
     const authRespKey = Buffer.from("8c7caa563cebc5c06bb15fc1a2d426c3", "hex");
-    const expectedAuthRespCiphertext = Buffer.from("570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852", "hex");
-
-    expect(
-      encryptAuthResponse(authRespKey, authResp, kpriv.privateKey)
-    ).to.deep.equal(
-      expectedAuthRespCiphertext
+    const expectedAuthRespCiphertext = Buffer.from(
+      "570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852",
+      "hex"
     );
+
+    expect(encryptAuthResponse(authRespKey, authResp, kpriv.privateKey)).to.deep.equal(expectedAuthRespCiphertext);
 
     const authTag = Buffer.from("27b5af763c446acd2749fe8e", "hex");
-    const expectedAuthHeaderRlp = Buffer.from("f8cc8c27b5af763c446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c658367636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852", "hex");
+    const expectedAuthHeaderRlp = Buffer.from(
+      "f8cc8c27b5af763c446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c658367636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852",
+      "hex"
+    );
 
     const authHeader = createAuthHeader(idNonce, ephemPK, expectedAuthRespCiphertext, authTag);
-    expect(
-      encodeAuthHeader(authHeader)
-    ).to.deep.equal(
-      expectedAuthHeaderRlp
-    );
-    expect(
-      decryptAuthHeader(authRespKey, authHeader)
-    ).to.deep.equal(
-      authResp
-    );
+    expect(encodeAuthHeader(authHeader)).to.deep.equal(expectedAuthHeaderRlp);
+    expect(decryptAuthHeader(authRespKey, authHeader)).to.deep.equal(authResp);
 
     const tag = Buffer.from("93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903", "hex");
     const encryptionKey = Buffer.from("9f2d77db7004bf8a1a85107ac686990b", "hex");
     const messagePlaintext = Buffer.from("01c20101", "hex");
 
-    const expectedAuthMessageRlp = Buffer.from("93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903f8cc8c27b5af763c446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c658367636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852a5d12a2d94b8ccb3ba55558229867dc13bfa3648", "hex");
+    const expectedAuthMessageRlp = Buffer.from(
+      "93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903f8cc8c27b5af763c446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c658367636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852a5d12a2d94b8ccb3ba55558229867dc13bfa3648",
+      "hex"
+    );
 
     expect(
       encode({
         type: PacketType.AuthMessage,
         tag,
         authHeader,
-        message: encryptMessage(
-          encryptionKey,
-          authTag,
-          messagePlaintext,
-          tag
-        ),
+        message: encryptMessage(encryptionKey, authTag, messagePlaintext, tag),
       })
-    ).to.deep.equal(
-      expectedAuthMessageRlp
-    );
+    ).to.deep.equal(expectedAuthMessageRlp);
   });
 });

--- a/test/session/service.test.ts
+++ b/test/session/service.test.ts
@@ -13,12 +13,12 @@ describe("session service", () => {
   const kp0 = createKeypair(
     KeypairType.secp256k1,
     Buffer.from("a93bedf04784c937059557c9dcb328f5f59fdb6e89295c30e918579250b7b01f", "hex"),
-    Buffer.from("022663242e1092ea19e6bb41d67aa69850541a623b94bbea840ddceaab39789894", "hex"),
+    Buffer.from("022663242e1092ea19e6bb41d67aa69850541a623b94bbea840ddceaab39789894", "hex")
   );
   const kp1 = createKeypair(
     KeypairType.secp256k1,
     Buffer.from("bd04e55f2a1424a4e69e96aad41cf763d2468d4358472e9f851569bdf47fb24c", "hex"),
-    Buffer.from("03eae9945b354e9212566bc3f2740f3a62b3e1eb227dbed809f6dc2d3ea848c82e", "hex"),
+    Buffer.from("03eae9945b354e9212566bc3f2740f3a62b3e1eb227dbed809f6dc2d3ea848c82e", "hex")
   );
 
   const addr0 = Multiaddr("/ip4/127.0.0.1/udp/49020");
@@ -56,39 +56,41 @@ describe("session service", () => {
   });
 
   it("should negotiate a session and receive a message from a cold sender (a->RandomPacket -> b->WhoAreYou -> a->AuthMessage)", async () => {
-    const receivedRandom = new Promise(resolve => transport1.once("packet", (sender: Multiaddr, data: Packet) => {
-      expect(sender.toString()).to.equal(addr0.toString());
-      expect(data.type).to.equal(PacketType.Message);
-      resolve();
-    }));
-    const receivedWhoAreYou = new Promise(resolve => transport0.once("packet", (sender: Multiaddr, data: Packet) => {
-      expect(sender.toString()).to.equal(addr1.toString());
-      expect(data.type).to.equal(PacketType.WhoAreYou);
-      resolve();
-    }));
+    const receivedRandom = new Promise((resolve) =>
+      transport1.once("packet", (sender: Multiaddr, data: Packet) => {
+        expect(sender.toString()).to.equal(addr0.toString());
+        expect(data.type).to.equal(PacketType.Message);
+        resolve();
+      })
+    );
+    const receivedWhoAreYou = new Promise((resolve) =>
+      transport0.once("packet", (sender: Multiaddr, data: Packet) => {
+        expect(sender.toString()).to.equal(addr1.toString());
+        expect(data.type).to.equal(PacketType.WhoAreYou);
+        resolve();
+      })
+    );
     // send a who are you when requested
     service1.on("whoAreYouRequest", (srcId, src, authTag) => {
       service1.sendWhoAreYou(src, srcId, BigInt(0), enr0, authTag);
     });
-    const establishedSession = new Promise(resolve => service1.once("established", (enr) => {
-      expect(enr).to.deep.equal(enr0);
-      resolve();
-    }));
-    const receivedMsg = new Promise(resolve => service1.once("message", (srcId, src, message) => {
-      resolve();
-    }));
+    const establishedSession = new Promise((resolve) =>
+      service1.once("established", (enr) => {
+        expect(enr).to.deep.equal(enr0);
+        resolve();
+      })
+    );
+    const receivedMsg = new Promise((resolve) =>
+      service1.once("message", (srcId, src, message) => {
+        resolve();
+      })
+    );
     service0.sendRequest(enr1, createFindNodeMessage(0));
-    await Promise.all([
-      receivedRandom,
-      receivedWhoAreYou,
-      establishedSession,
-      receivedMsg,
-    ]);
+    await Promise.all([receivedRandom, receivedWhoAreYou, establishedSession, receivedMsg]);
   });
   it("receiver should drop WhoAreYou packets from destinations without existing pending requests", async () => {
     transport0.send(addr1, createWhoAreYouPacket(enr1.nodeId, Buffer.alloc(12), BigInt(0)));
-    transport0.on("packet", () => expect.fail("transport0 should not receive any packets"))
+    transport0.on("packet", () => expect.fail("transport0 should not receive any packets"));
   });
-  it("should only accept WhoAreYou packets from destinations with existing pending requests", async () => {
-  });
+  it("should only accept WhoAreYou packets from destinations with existing pending requests", async () => {});
 });

--- a/test/transport/udp.test.ts
+++ b/test/transport/udp.test.ts
@@ -2,8 +2,8 @@
 import { expect } from "chai";
 import Multiaddr = require("multiaddr");
 
-import {PacketType, TAG_LENGTH, AUTH_TAG_LENGTH, MAGIC_LENGTH, IMessagePacket} from "../../src/packet";
-import {UDPTransportService} from "../../src/transport";
+import { PacketType, TAG_LENGTH, AUTH_TAG_LENGTH, MAGIC_LENGTH, IMessagePacket } from "../../src/packet";
+import { UDPTransportService } from "../../src/transport";
 
 describe("UDP transport", () => {
   const address = "127.0.0.1";
@@ -34,13 +34,8 @@ describe("UDP transport", () => {
       authTag: Buffer.alloc(AUTH_TAG_LENGTH),
       message: Buffer.alloc(44, 1),
     };
-    const received = new Promise((resolve) =>
-      a.once("packet", (sender, packet) =>
-        resolve([sender, packet])));
-    await b.send(
-      multiaddrA,
-      messagePacket,
-    );
+    const received = new Promise((resolve) => a.once("packet", (sender, packet) => resolve([sender, packet])));
+    await b.send(multiaddrA, messagePacket);
     // @ts-ignore
     const [rSender, rPacket] = await received;
     expect(rSender.toString()).to.deep.equal(multiaddrB.toString());

--- a/test/util/timeoutMap.test.ts
+++ b/test/util/timeoutMap.test.ts
@@ -8,7 +8,7 @@ describe("TimeoutMap", () => {
     const timeout = 15;
     const map = new TimeoutMap(timeout);
     map.set("foo", "bar");
-    await new Promise(resolve => setTimeout(resolve, timeout + 1));
+    await new Promise((resolve) => setTimeout(resolve, timeout + 1));
     expect(map.size).to.equal(0);
   });
   it("should call onTimeout after a timeout", async function () {
@@ -20,7 +20,7 @@ describe("TimeoutMap", () => {
       callbackCalled = true;
     });
     map.set("foo", "bar");
-    await new Promise(resolve => setTimeout(resolve, timeout + 1));
+    await new Promise((resolve) => setTimeout(resolve, timeout + 1));
     expect(map.size).to.equal(0);
     expect(callbackCalled).to.equal(true);
   });
@@ -29,10 +29,9 @@ describe("TimeoutMap", () => {
     const map = new TimeoutMap(timeout);
     map.set("foo", "bar");
     map.setTimeout("foo", timeout * 2);
-    await new Promise(resolve => setTimeout(resolve, timeout));
+    await new Promise((resolve) => setTimeout(resolve, timeout));
     expect(map.size).to.equal(1);
-    await new Promise(resolve => setTimeout(resolve, timeout + 1));
+    await new Promise((resolve) => setTimeout(resolve, timeout + 1));
     expect(map.size).to.equal(0);
   });
 });
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,6 +967,13 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-plugin-prettier@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
+  integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
@@ -1091,6 +1098,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -2333,6 +2345,18 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
See https://github.com/ChainSafe/lodestar/pull/1008 for the rationale.

**Note**: The `bracketSpacing` style of this repo is different than `ssz` and `lodestar`. I've changed the config to reflect it
https://github.com/ChainSafe/discv5/compare/master...dapplion:dapplion/prettier#diff-d9a52777b34c9360910514f53aad911dR9
Should we keep the same prettier config across all Eth2.0 tooling?

## How to incorporate
I would recommend for a repo maintainer to run
```
./node_modules/.bin/prettier --write '**/*.{ts,md}'
```
on its own, and commit on top of this PR when the repo is ready for the big resulting diff