### PR TITLE
Fix libp2p peer event

### DIFF
--- a/src/libp2p/discv5.ts
+++ b/src/libp2p/discv5.ts
@@ -69,9 +69,13 @@ export class Discv5Discovery extends EventEmitter {
         return;
       }
       for (const enr of enrs) {
+        const multiaddrTCP = enr.multiaddrTCP;
+        if (!multiaddrTCP) {
+          continue;
+        }
         this.emit("peer", {
-          id: enr.peerId(),
-          multiaddrs: [Multiaddr(enr.multiaddrTCP)],
+          id: await enr.peerId(),
+          multiaddrs: [multiaddrTCP],
         });
       }
     }


### PR DESCRIPTION
libp2p expects the "peer" event to look like this:
```
interface PeerEvent {
  id: PeerId;
  multiaddrs?: Multiaddr[];
  protocols?: string[];
}
```
We were instead returning:
```
interface BadPeerEvent {
  id: Promise<PeerId>;
  multiaddrs: Multiaddr[]; // but with an undefined multiaddr X_X
}
```
Fix `id` to await the `PeerId`
And skip emitting an event if the given multiaddr, eg: `enr.multiaddrTCP` is undefined.

cc @3xtr4t3rr3str14l who found the bug