### PR TITLE
Print out node id at startup

### DIFF
--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -159,7 +159,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
       log("Starting discv5 service failed -- already started");
       return;
     }
-    log("Starting discv5 service");
+    log(`Starting discv5 service with node id ${this.enr.nodeId}`);
     this.kbuckets.on("pendingEviction", this.onPendingEviction);
     this.kbuckets.on("appliedEviction", this.onAppliedEviction);
     this.sessionService.on("established", this.onEstablished);

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -90,7 +90,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    * Starts the session service, starting the underlying UDP transport service.
    */
   public async start(): Promise<void> {
-    log("Starting session service");
+    log(`Starting session service with node id ${this.enr.nodeId}`);
     this.transport.on("packet", this.onPacket);
     await this.transport.start();
   }


### PR DESCRIPTION
I'd like to print out our node id at startup time so that it's easier to debug with other nodes/peers