### PR TITLE
Set ip address to enr at startup

### DIFF
--- a/src/libp2p/discv5.ts
+++ b/src/libp2p/discv5.ts
@@ -14,7 +14,8 @@ export interface IDiscv5DiscoveryInputOptions {
   /**
    * The bind multiaddr for the discv5 UDP server
    *
-   * NOTE: This MUST be a udp multiaddr
+   * NOTE: This MUST be a udp multiaddr, ip should be "0.0.0.0" or public/static ip address.
+   * For example /ip4/0.0.0.0/udp/9000 or /ip4/125.234.115.178/udp/9000 NOT /ip4/192.168.1.1/udp/9000
    */
   bindAddr: string;
   /**


### PR DESCRIPTION
resolves https://github.com/ChainSafe/lodestar/issues/1295

It's most likely we'll either configure `bootEnr` as `0.0.0.0` or a public/static ip address instead of DNS or local ip address, so just set to ENR if we found it's not 0.0.0.0