### PR TITLE
Fix kad lookup bugs in NODES response

### DIFF
--- a/src/kademlia/kademlia.ts
+++ b/src/kademlia/kademlia.ts
@@ -121,7 +121,7 @@ export class KademliaRoutingTable extends (EventEmitter as { new (): BucketEvent
   }
 
   valuesOfDistance(value: number): ENR[] {
-    const bucket = this.buckets[value];
+    const bucket = this.buckets[value - 1];
     return bucket === undefined ? [] : bucket.values();
   }
 

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -562,7 +562,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
       }
       return;
     }
-    const nodes = this.kbuckets.valuesOfDistance(distance).slice(15);
+    const nodes = this.kbuckets.valuesOfDistance(distance).slice(0, 15);
     if (nodes.length === 0) {
       log("Sending empty NODES response to %s", srcId);
       try {


### PR DESCRIPTION
Fix two bugs:
1. we weren't sending nodes of the right distance, off by one
2. we weren't sending as many nodes in the bucket as we could, only potentially the last node in the bucket