### PR TITLE
Add lookupTimeout configuration

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -21,6 +21,7 @@ export const defaultConfig: IDiscv5Config = {
   sessionEstablishTimeout: 15 * 1000,
   lookupParallelism: 3,
   lookupNumResults: 16,
+  lookupTimeout: 60 * 1000,
   pingInterval: 300 * 1000,
   enrUpdate: true,
 };

--- a/src/kademlia/types.ts
+++ b/src/kademlia/types.ts
@@ -54,6 +54,12 @@ export interface ILookupConfig {
    * Defaults to the maximum number of entries in a single kbucket.
    */
   lookupNumResults: number;
+  /**
+   * Maximum amount of time to spend on a single lookup
+   *
+   * Declared in milliseconds
+   */
+  lookupTimeout: number;
 }
 
 export interface ILookupEvents {


### PR DESCRIPTION
Add a `lookupTimeout` configuration option.
Sets the maximum amount of time to spend on each lookup. Default to 60 seconds.