### PR TITLE
Refactor ENR multiaddr handling

### DIFF
--- a/src/libp2p/discv5.ts
+++ b/src/libp2p/discv5.ts
@@ -83,7 +83,7 @@ export class Discv5Discovery extends EventEmitter {
   }
 
   handleEnr = async (enr: ENR): Promise<void> => {
-    const multiaddrTCP = enr.multiaddrTCP;
+    const multiaddrTCP = enr.getLocationMultiaddr("tcp");
     if (!multiaddrTCP) {
       return;
     }

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -524,11 +524,11 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
           `/${isIp.v4(message.recipientIp) ? "ip4" : "ip6"}/${message.recipientIp}/udp/${message.recipientPort}`
         )
       );
-      const currentAddr = this.enr.multiaddrUDP;
+      const currentAddr = this.enr.getLocationMultiaddr("udp");
       const votedAddr = this.addrVotes.best(currentAddr);
       if ((currentAddr && votedAddr && !votedAddr.equals(currentAddr)) || (!currentAddr && votedAddr)) {
         log("Local ENR (IP & UDP) updated: %s", votedAddr);
-        this.enr.multiaddrUDP = votedAddr;
+        this.enr.setLocationMultiaddr(votedAddr);
         this.emit("multiaddrUpdated", votedAddr);
       }
     }

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -131,7 +131,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    */
   public sendRequest(dstEnr: ENR, message: RequestMessage): void {
     const dstId = dstEnr.nodeId;
-    const dst = dstEnr.multiaddrUDP;
+    const dst = dstEnr.getLocationMultiaddr("udp");
     if (!dst) {
       throw new Error("ENR must have udp socket data");
     }

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -316,7 +316,7 @@ export class Session {
   updateTrusted(): boolean {
     if (this.remoteEnr) {
       const hasSameMultiaddr = (multiaddr: Multiaddr, enr: ENR): boolean => {
-        const enrMultiaddr = enr.multiaddrUDP;
+        const enrMultiaddr = enr.getLocationMultiaddr("udp");
         return enrMultiaddr ? enrMultiaddr.equals(multiaddr) : false;
       };
       switch (this.trusted) {

--- a/test/enr.test.ts
+++ b/test/enr.test.ts
@@ -52,19 +52,16 @@ describe("ENR Multiformats support", () => {
     record.set("ip", tuples0[0][1]);
     record.set("udp", tuples0[1][1]);
     // and get the multiaddr
-    expect(record.multiaddrUDP!.toString()).to.equal(multi0.toString());
+    expect(record.getLocationMultiaddr("udp")!.toString()).to.equal(multi0.toString());
     // set the multiaddr
     const multi1 = Multiaddr("/ip4/0.0.0.0/udp/30300");
-    record.multiaddrUDP = multi1;
+    record.setLocationMultiaddr(multi1);
     // and get the multiaddr
-    expect(record.multiaddrUDP!.toString()).to.equal(multi1.toString());
+    expect(record.getLocationMultiaddr("udp")!.toString()).to.equal(multi1.toString());
     // and get the underlying records
     const tuples1 = multi1.tuples();
     expect(record.get("ip")).to.deep.equal(tuples1[0][1]);
     expect(record.get("udp")).to.deep.equal(tuples1[1][1]);
-    // unset multiaddrs
-    record.multiaddrUDP = undefined;
-    expect(record.multiaddrUDP).to.be.undefined;
   });
   it("should get / set TCP multiaddr", () => {
     const multi0 = Multiaddr("/ip4/127.0.0.1/tcp/30303");
@@ -73,12 +70,12 @@ describe("ENR Multiformats support", () => {
     record.set("ip", tuples0[0][1]);
     record.set("tcp", tuples0[1][1]);
     // and get the multiaddr
-    expect(record.multiaddrTCP!.toString()).to.equal(multi0.toString());
+    expect(record.getLocationMultiaddr("tcp")!.toString()).to.equal(multi0.toString());
     // set the multiaddr
     const multi1 = Multiaddr("/ip4/0.0.0.0/tcp/30300");
-    record.multiaddrTCP = multi1;
+    record.setLocationMultiaddr(multi1);
     // and get the multiaddr
-    expect(record.multiaddrTCP!.toString()).to.equal(multi1.toString());
+    expect(record.getLocationMultiaddr("tcp")!.toString()).to.equal(multi1.toString());
     // and get the underlying records
     const tuples1 = multi1.tuples();
     expect(record.get("ip")).to.deep.equal(tuples1[0][1]);

--- a/test/session/service.test.ts
+++ b/test/session/service.test.ts
@@ -28,8 +28,8 @@ describe("session service", () => {
   const enr0 = ENR.createV4(kp0.publicKey);
   const enr1 = ENR.createV4(kp1.publicKey);
 
-  enr0.multiaddrUDP = addr0;
-  enr1.multiaddrUDP = addr1;
+  enr0.setLocationMultiaddr(addr0);
+  enr1.setLocationMultiaddr(addr1);
 
   const magic0 = createMagic(enr0.nodeId);
   const magic1 = createMagic(enr1.nodeId);


### PR DESCRIPTION
Breaking changes:
Instead of using getter/setters `enr.multiaddrUDP` and `enr.multiaddrTCP`,
Use `getLocationMultiaddr(protocol: string): Multiaddr | undefined` and `setLocationMultiaddr(multiaddr: Multiaddr): void`.
This allows us to deduplicate all multiaddr logic into a single getter/setter as well as support multiaddr selection by specific ip4/6 subprotocols like `"udp4"` or `"tcp6"`.
Also add `getFullMultiaddr(protocol)` which returns the multiaddr with `/p2p/${peerId}` appended 