### PR TITLE
Fix multiaddr port after decoding enr from a txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,8 @@ lib
 # swp file
 *.swp
 
+# ide
+.vscode
+
 # others
 package-lock.json

--- a/src/enr/enr.ts
+++ b/src/enr/enr.ts
@@ -9,6 +9,7 @@ import { ERR_INVALID_ID, ERR_NO_SIGNATURE, MAX_RECORD_SIZE } from "./constants";
 import * as v4 from "./v4";
 import { ENRKey, ENRValue, SequenceNumber, NodeId } from "./types";
 import { createKeypair, KeypairType, IKeypair, createPeerIdFromKeypair, createKeypairFromPeerId } from "../keypair";
+import { toNewUint8Array } from "../util";
 
 export class ENR extends Map<ENRKey, ENRValue> {
   public seq: SequenceNumber;
@@ -128,7 +129,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
   get tcp(): number | undefined {
     const raw = this.get("tcp");
     if (raw) {
-      return muConvert.toString(Multiaddr.protocols.names.tcp.code, raw) as number;
+      return muConvert.toString(Multiaddr.protocols.names.tcp.code, toNewUint8Array(raw)) as number;
     } else {
       return undefined;
     }
@@ -145,7 +146,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
   get udp(): number | undefined {
     const raw = this.get("udp");
     if (raw) {
-      return muConvert.toString(Multiaddr.protocols.names.udp.code, raw) as number;
+      return muConvert.toString(Multiaddr.protocols.names.udp.code, toNewUint8Array(raw)) as number;
     } else {
       return undefined;
     }

--- a/src/util/toBuffer.ts
+++ b/src/util/toBuffer.ts
@@ -1,3 +1,9 @@
 export function toBuffer(arr: Uint8Array): Buffer {
   return Buffer.from(arr.buffer, arr.byteOffset, arr.length);
 }
+
+// multiaddr 8.0.0 expects an Uint8Array with internal buffer starting at 0 offset
+export function toNewUint8Array(buf: Uint8Array): Uint8Array {
+  const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  return new Uint8Array(arrayBuffer);
+}

--- a/test/enr.test.ts
+++ b/test/enr.test.ts
@@ -27,9 +27,12 @@ describe("ENR", () => {
   });
 
   it("should encode/decode to text encoding", () => {
+    // spec enr https://eips.ethereum.org/EIPS/eip-778
     const testTxt =
       "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
     const decoded = ENR.decodeTxt(testTxt);
+    expect(decoded.udp).to.be.equal(30303);
+    expect(decoded.ip).to.be.equal("127.0.0.1");
     expect(decoded).to.deep.equal(record);
     expect(record.encodeTxt(privateKey)).to.equal(testTxt);
   });

--- a/test/enr/enr.test.ts
+++ b/test/enr/enr.test.ts
@@ -4,6 +4,7 @@ import { ENR } from "../../src/enr/enr";
 import { createKeypairFromPeerId } from "../../src/keypair";
 import { toHex } from "../../src/util";
 import { ERR_INVALID_ID } from "../../src/enr/constants";
+import Multiaddr from "multiaddr";
 
 describe("ENR", function () {
   describe("decodeTxt", () => {
@@ -11,10 +12,13 @@ describe("ENR", function () {
       const peerId = await PeerId.create({ keyType: "secp256k1" });
       const enr = ENR.createFromPeerId(peerId);
       const keypair = createKeypairFromPeerId(peerId);
+      enr.setLocationMultiaddr(new Multiaddr("/ip4/18.223.219.100/udp/9000"));
       const txt = enr.encodeTxt(keypair.privateKey);
       expect(txt.slice(0, 4)).to.be.equal("enr:");
       const enr2 = ENR.decodeTxt(txt);
       expect(toHex(enr2.signature as Buffer)).to.be.equal(toHex(enr.signature as Buffer));
+      const multiaddr = enr2.getLocationMultiaddr("udp")!;
+      expect(multiaddr.toString()).to.be.equal("/ip4/18.223.219.100/udp/9000");
     });
 
     it("should decode valid enr successfully", () => {


### PR DESCRIPTION
js-multiaddr 8.0.0 only expects a Buffer with 0 byte offset, this caused discv5 to use incorrect udp port after decoding from enr and cannot do handshake with other nodes. The issue is (for later reference):
+ Discv5 gets inccorrect udp port after decoding an enr from txt
+ It sends random packets to nodes
+ Receive no packet from then

We expect it to be fixed in https://github.com/multiformats/js-multiaddr/pull/146/files 