### PR TITLE
fix: AddrVotes.best

### DIFF
--- a/src/service/addrVotes.ts
+++ b/src/service/addrVotes.ts
@@ -50,7 +50,7 @@ export class AddrVotes {
       tiebreaker = new Multiaddr(Object.keys(this.tallies)[0]);
     }
     const tiebreakerStr = tiebreaker.toString();
-    let best: [string, number] = [tiebreakerStr, this.tallies[tiebreakerStr] || 0];
+    let best: [string, number] = [tiebreakerStr, this.tallies[tiebreakerStr] ?? 0];
     for (const [addrStr, total] of Object.entries(this.tallies)) {
       if (total > best[1]) {
         best = [addrStr, total];

--- a/src/service/addrVotes.ts
+++ b/src/service/addrVotes.ts
@@ -50,7 +50,7 @@ export class AddrVotes {
       tiebreaker = new Multiaddr(Object.keys(this.tallies)[0]);
     }
     const tiebreakerStr = tiebreaker.toString();
-    let best: [string, number] = [tiebreakerStr, this.tallies[tiebreakerStr]];
+    let best: [string, number] = [tiebreakerStr, this.tallies[tiebreakerStr] || 0];
     for (const [addrStr, total] of Object.entries(this.tallies)) {
       if (total > best[1]) {
         best = [addrStr, total];


### PR DESCRIPTION
If `tiebreakerStr` does not exist in `this.tallies`, `best[1]` will be `undefined`, and that will cause comparing failed.
```js
console.log(1 > undefined);
// false
```