### PR TITLE
Add handlers/helpers for TALKREQ/TALKRESP message types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/discv5",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Discovery V5",
   "main": "lib/index.js",
   "files": [

--- a/src/message/create.ts
+++ b/src/message/create.ts
@@ -1,7 +1,16 @@
 import { randomBytes } from "bcrypto/lib/random";
 import { toBigIntBE } from "bigint-buffer";
 
-import { RequestId, IPingMessage, MessageType, IPongMessage, IFindNodeMessage, INodesMessage } from "./types";
+import {
+  RequestId,
+  IPingMessage,
+  MessageType,
+  IPongMessage,
+  IFindNodeMessage,
+  INodesMessage,
+  ITalkReqMessage,
+  ITalkRespMessage,
+} from "./types";
 import { SequenceNumber, ENR } from "../enr";
 
 export function createRequestId(): RequestId {
@@ -45,5 +54,21 @@ export function createNodesMessage(id: RequestId, total: number, enrs: ENR[]): I
     id,
     total,
     enrs,
+  };
+}
+
+export function createTalkRequestMessage(request: string): ITalkReqMessage {
+  return {
+    type: MessageType.TALKREQ,
+    id: createRequestId(),
+    protocol: Buffer.from("0x01"),
+    request: Buffer.from(request),
+  };
+}
+export function createTalkResponseMessage(message: ITalkReqMessage): ITalkRespMessage {
+  return {
+    type: MessageType.TALKRESP,
+    id: message.id,
+    response: Buffer.from(message.request.toString("utf-8") + " - back to you"),
   };
 }

--- a/src/message/create.ts
+++ b/src/message/create.ts
@@ -57,18 +57,18 @@ export function createNodesMessage(id: RequestId, total: number, enrs: ENR[]): I
   };
 }
 
-export function createTalkRequestMessage(request: string | Buffer, protocol: string): ITalkReqMessage {
+export function createTalkRequestMessage(request: string | Buffer, protocol: string | Uint8Array): ITalkReqMessage {
   return {
     type: MessageType.TALKREQ,
     id: createRequestId(),
-    protocol: Buffer.from(protocol.toString()),
+    protocol: Buffer.from(protocol),
     request: Buffer.from(request),
   };
 }
-export function createTalkResponseMessage(request: ITalkReqMessage, payload: Buffer): ITalkRespMessage {
+export function createTalkResponseMessage(requestId: RequestId, payload: Uint8Array): ITalkRespMessage {
   return {
     type: MessageType.TALKRESP,
-    id: request.id,
-    response: payload,
+    id: requestId,
+    response: Buffer.from(payload),
   };
 }

--- a/src/message/create.ts
+++ b/src/message/create.ts
@@ -57,18 +57,18 @@ export function createNodesMessage(id: RequestId, total: number, enrs: ENR[]): I
   };
 }
 
-export function createTalkRequestMessage(request: string): ITalkReqMessage {
+export function createTalkRequestMessage(request: string | Buffer, protocol: string): ITalkReqMessage {
   return {
     type: MessageType.TALKREQ,
     id: createRequestId(),
-    protocol: Buffer.from("0x01"),
+    protocol: Buffer.from(protocol.toString()),
     request: Buffer.from(request),
   };
 }
-export function createTalkResponseMessage(message: ITalkReqMessage): ITalkRespMessage {
+export function createTalkResponseMessage(request: ITalkReqMessage, payload: Buffer): ITalkRespMessage {
   return {
     type: MessageType.TALKRESP,
-    id: message.id,
-    response: Buffer.from(message.request.toString("utf-8") + " - back to you"),
+    id: request.id,
+    response: payload,
   };
 }

--- a/src/message/create.ts
+++ b/src/message/create.ts
@@ -57,7 +57,7 @@ export function createNodesMessage(id: RequestId, total: number, enrs: ENR[]): I
   };
 }
 
-export function createTalkRequestMessage(request: string | Buffer, protocol: string | Uint8Array): ITalkReqMessage {
+export function createTalkRequestMessage(request: string | Uint8Array, protocol: string | Uint8Array): ITalkReqMessage {
   return {
     type: MessageType.TALKREQ,
     id: createRequestId(),

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -315,7 +315,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
       log(`Sent TALKRESP message to node ${enr.id}`);
     } else {
       if (!addr && enr) {
-        log(`No ip + udp port found for node ${enr.id}`);
+        log(`No ip + udp port found for node ${srcId}`);
       } else {
         log(`Node ${srcId} not found`);
       }

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -21,17 +21,17 @@ export interface IDiscv5Events {
    */
   multiaddrUpdated: (addr: Multiaddr) => void;
   /**
-   * A TALKREQ message was received. Messages
+   * A TALKREQ message was received.
    *
    * The message object is returned.
    */
-  talkReqReceived: (srcId: NodeId, message: ITalkReqMessage) => void;
+  talkReqReceived: (srcId: NodeId, enr: ENR | null, message: ITalkReqMessage) => void;
   /**
    * A TALKREQ message was received.
    *
    * The message object is returned.
    */
-  talkRespReceived: (srcId: NodeId, message: ITalkRespMessage) => void;
+  talkRespReceived: (srcId: NodeId, enr: ENR | null, message: ITalkRespMessage) => void;
 }
 
 export type Discv5EventEmitter = StrictEventEmitter<EventEmitter, IDiscv5Events>;

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -3,7 +3,7 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import { Multiaddr } from "multiaddr";
 
 import { ENR, NodeId } from "../enr";
-import { RequestMessage } from "../message";
+import { ITalkReqMessage, ITalkRespMessage, RequestMessage } from "../message";
 
 export interface IDiscv5Events {
   /**
@@ -20,6 +20,18 @@ export interface IDiscv5Events {
    * Our local ENR IP address has been updated
    */
   multiaddrUpdated: (addr: Multiaddr) => void;
+  /**
+   * A TALKREQ message was received. Messages
+   *
+   * The message object is returned.
+   */
+  talkReqReceived: (srcId: NodeId, message: ITalkReqMessage) => void;
+  /**
+   * A TALKREQ message was received.
+   *
+   * The message object is returned.
+   */
+  talkRespReceived: (srcId: NodeId, message: ITalkRespMessage) => void;
 }
 
 export type Discv5EventEmitter = StrictEventEmitter<EventEmitter, IDiscv5Events>;


### PR DESCRIPTION
Simple TALKREQ/TALKRESP message handling

- discv5.service emits event when a TALKREQ/TALKRESP message is received 
- `discv5.sendTalkReq` broadcasts a a provided `payload` to all nodes in routing table with a given `protocol` in the `TALKREQ` message format
- `discv5.sendTalkResp` sends a TALKRESP message to a specified `nodeId` with a provided `payload`