### PR TITLE
Optimize enr  getLocationMultiaddr

### DIFF
--- a/bench/enr/index.bench.ts
+++ b/bench/enr/index.bench.ts
@@ -1,0 +1,19 @@
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
+import {generateKeypair, KeypairType} from "../../src/keypair";
+import {ENR} from "../../src/enr";
+
+describe("ENR", function() {
+  setBenchOpts({runs: 50000});
+
+  const keypairWithPrivateKey = generateKeypair(KeypairType.secp256k1);
+  const enr = ENR.createV4(keypairWithPrivateKey.privateKey);
+  enr.ip = "127.0.0.1";
+  enr.tcp = 8080;
+
+  itBench("ENR - getLocationMultiaddr - udp", () => {
+    return enr.getLocationMultiaddr("udp");
+  });
+  itBench("ENR - getLocationMultiaddr - tcp", () => {
+    return enr.getLocationMultiaddr("tcp");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/ip6addr": "^0.2.0",
     "@types/mocha": "^8.0.3",
     "@types/node": "^12.0.10",
+    "@types/varint": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
     "@typescript-eslint/parser": "^2.7.0",
     "chai": "^4.2.0",
@@ -67,6 +68,7 @@
     "multiaddr": "^9.0.0",
     "peer-id": "^0.14.8",
     "rlp": "^2.2.6",
-    "strict-event-emitter-types": "^2.0.0"
+    "strict-event-emitter-types": "^2.0.0",
+    "varint": "^6.0.0"
   }
 }

--- a/src/enr/enr.ts
+++ b/src/enr/enr.ts
@@ -4,7 +4,7 @@ import { toBigIntBE } from "bigint-buffer";
 import * as RLP from "rlp";
 import PeerId from "peer-id";
 import muConvert from "multiaddr/src/convert";
-import {encode as varintEncode} from "varint";
+import { encode as varintEncode } from "varint";
 
 import { ERR_INVALID_ID, ERR_NO_SIGNATURE, MAX_RECORD_SIZE } from "./constants";
 import * as v4 from "./v4";

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,6 +499,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/varint@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/varint/-/varint-6.0.0.tgz#4ad73c23cbc9b7e44379a7729ace7ed9c8bc9854"
+  integrity sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@^2.7.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"


### PR DESCRIPTION
Relies on #124 (for benchmark infra)
Seen in profiles
![createPeerIdFromKeypair](https://user-images.githubusercontent.com/1348242/126829615-1288683a-a1a9-4559-9c26-d4da1a2c1696.png)



Added benchmarks to show improvement:

Before:
```
  ENR
    ✓ ENR - getLocationMultiaddr - udp                                    705716.3 ops/s    1.417000 us/op        -      57023 runs  0.104 s
    ✓ ENR - getLocationMultiaddr - tcp                                    92378.75 ops/s    10.82500 us/op        -      50000 runs  0.565 s
```

After:
```
  ENR                                                                                                                                                                                          
    ✓ ENR - getLocationMultiaddr - udp                                     1739130 ops/s    575.0000 ns/op        -     112916 runs  0.106 s
    ✓ ENR - getLocationMultiaddr - tcp                                    477783.1 ops/s    2.093000 us/op        -      50000 runs  0.125 s
```