### PR TITLE
Add metrics

### DIFF
--- a/src/libp2p/discv5.ts
+++ b/src/libp2p/discv5.ts
@@ -4,7 +4,7 @@ import { Multiaddr } from "multiaddr";
 import { randomBytes } from "libp2p-crypto";
 import { AbortController } from "@chainsafe/abort-controller";
 
-import { Discv5, ENRInput } from "../service";
+import { Discv5, ENRInput, IDiscv5Metrics } from "../service";
 import { createNodeId, ENR } from "../enr";
 import { IDiscv5Config } from "../config";
 import { toBuffer } from "../util";
@@ -28,6 +28,10 @@ export interface IDiscv5DiscoveryInputOptions extends Partial<IDiscv5Config> {
    * Amount of time in milliseconds to wait between lookups
    */
   searchInterval: number;
+  /**
+   * Optional metrics
+   */
+  metrics?: IDiscv5Metrics;
   /**
    * Enable/disable discv5
    * Note: this option is handled within libp2p, not within discv5
@@ -57,6 +61,7 @@ export class Discv5Discovery extends EventEmitter {
       peerId: options.peerId,
       multiaddr: new Multiaddr(options.bindAddr),
       config: options,
+      metrics: options.metrics,
     });
     this.searchInterval = options.searchInterval;
     this.started = false;

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -48,3 +48,28 @@ export interface IActiveRequest {
 }
 
 export type ENRInput = ENR | string;
+
+// Metrics
+
+type Labels<T extends string> = Partial<Record<T, string | number>>;
+interface IGauge<T extends string = string> {
+  inc(value?: number): void;
+  inc(labels: Labels<T>, value?: number): void;
+  set(value: number): void;
+  set(labels: Labels<T>, value: number): void;
+  collect(): void;
+}
+
+export interface IDiscv5Metrics {
+  /** Total size of the kad table */
+  kadTableSize: IGauge;
+  /** Total number of active sessions */
+  activeSessionCount: IGauge;
+  /** Total number of connected peers */
+  connectedPeerCount: IGauge;
+
+  /** Total number messages sent by message type */
+  sentMessageCount: IGauge<"type">;
+  /** Total number messages received by message type */
+  rcvdMessageCount: IGauge<"type">;
+}

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -115,6 +115,10 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
     this.sessions.clear();
   }
 
+  public sessionsSize(): number {
+    return this.sessions.size;
+  }
+
   public updateEnr(enr: ENR): void {
     const session = this.sessions.get(enr.nodeId);
     if (session) {


### PR DESCRIPTION
Adds an _optional_ metrics to be passed in, w/ several defined metrics:
- total size of kademlia table
- count of active sessions
- count of active peers
- count of sent messages by message type
- count of received messages by message type

We can add more metrics as we think of them