### PR TITLE
Add lookup count metric

### DIFF
--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -149,6 +149,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
       metrics.kadTableSize.collect = () => metrics.kadTableSize.set(discv5.kbuckets.size);
       metrics.connectedPeerCount.collect = () => metrics.connectedPeerCount.set(discv5.connectedPeers.size);
       metrics.activeSessionCount.collect = () => metrics.activeSessionCount.set(discv5.sessionService.sessionsSize());
+      metrics.lookupCount.collect = () => metrics.lookupCount.set(this.nextLookupId - 1);
     }
   }
 

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -67,6 +67,8 @@ export interface IDiscv5Metrics {
   activeSessionCount: IGauge;
   /** Total number of connected peers */
   connectedPeerCount: IGauge;
+  /** Total number of attempted lookups */
+  lookupCount: IGauge;
 
   /** Total number messages sent by message type */
   sentMessageCount: IGauge<"type">;


### PR DESCRIPTION
While integrating the metrics into lodestar ( chainsafe/lodestar#3103 ) it seemed like this useful metric was missing
We want to track how often lookups are triggered, especially when they are triggered by lodestar on demand ( chainsafe/lodestar#3104 )