### PR TITLE
Query multiple distances at once in lookups

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -20,6 +20,7 @@ export const defaultConfig: IDiscv5Config = {
   sessionTimeout: 86400 * 1000, // 1 day
   sessionEstablishTimeout: 15 * 1000,
   lookupParallelism: 3,
+  lookupRequestLimit: 3,
   lookupNumResults: 16,
   lookupTimeout: 60 * 1000,
   pingInterval: 300 * 1000,

--- a/src/kademlia/types.ts
+++ b/src/kademlia/types.ts
@@ -48,6 +48,10 @@ export interface ILookupConfig {
    */
   lookupParallelism: number;
   /**
+   * Amount of distances requested in a single Findnode message for a lookup or query
+   */
+  lookupRequestLimit: number;
+  /**
    * Number of results to produce.
    *
    * The number of closest peers that a query must obtain successful results for before it terminates.

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -15,7 +15,7 @@ import {
   KademliaRoutingTable,
   log2Distance,
   ILookupPeer,
-  findNodeLog2Distance,
+  findNodeLog2Distances,
   Lookup,
 } from "../kademlia";
 import {
@@ -381,13 +381,9 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
    */
   private sendLookup(lookupId: number, target: NodeId, peer: ILookupPeer): void {
     const peerId = peer.nodeId;
-    const distance = findNodeLog2Distance(target, peer);
-    // send request if distance is not 0
-    let succeeded = Boolean(distance);
-    if (succeeded) {
-      log("Sending lookup. Id: %d, Iteration: %d, Node: %s", lookupId, peer.iteration, peerId);
-      succeeded = this.sendRequest(peer.nodeId, createFindNodeMessage([distance]), lookupId);
-    }
+    const distances = findNodeLog2Distances(target, peer, this.config);
+    log("Sending lookup. Id: %d, Iteration: %d, Node: %s", lookupId, peer.iteration, peerId);
+    const succeeded = this.sendRequest(peer.nodeId, createFindNodeMessage(distances), lookupId);
     // request errored (or request was not possible)
     if (!succeeded) {
       const lookup = this.activeLookups.get(lookupId);


### PR DESCRIPTION
Discv5.1 allows FINDNODE to request nodes at multiple distances.

We can use this to get more diverse nodes per request.
Inspiration here: https://github.com/status-im/nim-eth/blob/master/eth/p2p/discoveryv5/protocol.nim#L101