### PR TITLE
AddrVotes: Fix timeout map

### DIFF
--- a/src/service/addrVotes.ts
+++ b/src/service/addrVotes.ts
@@ -9,7 +9,7 @@ export class AddrVotes {
   private tallies: Record<string, number>;
 
   constructor() {
-    this.votes = new TimeoutMap(IP_VOTE_TIMEOUT, this.removeTally);
+    this.votes = new TimeoutMap(IP_VOTE_TIMEOUT, this.removeVote);
     this.tallies = {};
   }
 
@@ -33,10 +33,6 @@ export class AddrVotes {
     this.tallies[addrStr] += 1;
   }
 
-  removeTally = (addrStr: string): void => {
-    this.tallies[addrStr] -= 1;
-  };
-
   clear(): void {
     this.votes.clear();
     this.tallies = {};
@@ -58,4 +54,11 @@ export class AddrVotes {
     }
     return new Multiaddr(best[0]);
   }
+
+  private removeTally = (addrStr: string): void => {
+    const total = this.tallies[addrStr];
+    if (!isNaN(total)) {
+      this.tallies[addrStr] = total - 1;
+    }
+  };
 }


### PR DESCRIPTION
**Motivation**
As noted in https://github.com/ChainSafe/lodestar/issues/3390#issuecomment-956042391, the timeout map of `votes` in `AddrVotes` uses the wrong callback function, and it causes the `tallies` map contains > 34000 entries with node id as key `NaN` as value
<img width="1663" alt="Screen Shot 2021-11-01 at 15 24 45" src="https://user-images.githubusercontent.com/10568965/139648508-e31a7270-0071-425e-b2c4-b97b3ea051d7.png">

**Description**
Fix the creation of `votes` timed out map