### PR TITLE
fix: index bucket by node id

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "tsc --declaration --outDir lib",
     "prepublishOnly": "yarn build",
     "lint": "eslint --color --ext .ts src/",
-    "test": "mocha -r ts-node/register 'test/**/*.test.ts'"
+    "test": "mocha -r ts-node/register 'test/**/*.test.ts'",
+    "benchmark": "benchmark -r ts-node/register 'test/**/*.perf.ts'"
   },
   "pre-push": [
     "lint"
@@ -34,7 +35,7 @@
   },
   "homepage": "https://github.com/ChainSafe/discv5#readme",
   "devDependencies": {
-    "@dapplion/benchmark": "^0.1.6",
+    "@dapplion/benchmark": "^0.2.2",
     "@types/bn.js": "^4.11.5",
     "@types/chai": "^4.2.0",
     "@types/debug": "^4.1.5",

--- a/src/kademlia/bucket.ts
+++ b/src/kademlia/bucket.ts
@@ -243,6 +243,16 @@ export class Bucket extends (EventEmitter as { new (): BucketEventEmitter }) {
   }
 
   /**
+   * Get an entry by index
+   */
+  getByIndex(index: number): IEntry<ENR> {
+    if (index >= this.bucket.length) {
+      throw new Error(`Invalid index in bucket: ${index}`);
+    }
+    return this.bucket[index];
+  }
+
+  /**
    * Remove a value from the bucket by index
    */
   removeByIndex(index: number): ENR {

--- a/test/kademlia/bucket.test.ts
+++ b/test/kademlia/bucket.test.ts
@@ -1,0 +1,150 @@
+/* eslint-env mocha */
+import { expect } from "chai";
+import { ENR, v4 } from "../../src/enr";
+import {Bucket} from "../../src/kademlia/bucket";
+import { EntryStatus } from "../../src/kademlia/types";
+
+describe.only("Bucket", () => {
+  const timeoutMs = 100;
+  let bucket: Bucket;
+  const enr0 = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+  const enr1 = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+  const enr2 = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+  const [nodeId0, nodeId1, nodeId2] = [enr0.nodeId, enr1.nodeId, enr2.nodeId];
+
+  beforeEach(() => {
+    bucket = new Bucket(4, timeoutMs);
+    bucket.add(enr0, EntryStatus.Disconnected);
+    bucket.add(enr1, EntryStatus.Connected);
+    bucket.add(enr2, EntryStatus.Connected);
+  });
+
+  it("addConnected", () => {
+    // not full
+    const newEnr = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    bucket.addConnected(newEnr);
+    expect(bucket.getValue(newEnr.nodeId)).to.be.equal(newEnr);
+    expectCorrectNodeIdMap();
+
+    // full
+    const newEnr2 = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    bucket.addConnected(newEnr);
+    expect(bucket.getValue(newEnr2.nodeId)).to.be.undefined;
+    expectCorrectNodeIdMap();
+  });
+
+  it("addDisconnected", () => {
+    // not full
+    const newEnr = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    bucket.addDisconnected(newEnr);
+    expect(bucket.getValue(newEnr.nodeId)).to.be.equal(newEnr);
+    expectCorrectNodeIdMap();
+
+    // full
+    const newEnr2 = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    bucket.addDisconnected(newEnr);
+    expect(bucket.getValue(newEnr2.nodeId)).to.be.undefined;
+    expectCorrectNodeIdMap();
+  });
+
+  it("updateValue", () => {
+    enr1.ip = "127.0.0.1";
+    expectCorrectNodeIdMap();
+  });
+
+  it("updateStatus", () => {
+    // strange node id
+    bucket.updateStatus("wrong node id", EntryStatus.Connected);
+    expectCorrectNodeIdMap();
+
+    // pending
+    const newEnr = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    bucket.addPending(newEnr, EntryStatus.Connected);
+    bucket.updateStatus(newEnr.nodeId, EntryStatus.Disconnected);
+    expect(bucket.getWithPending(newEnr.nodeId)?.value).to.be.equal(newEnr);
+    expectCorrectNodeIdMap();
+
+    // existing enr, unchanged status
+    bucket.updateStatus(nodeId1, EntryStatus.Connected);
+    expectCorrectNodeIdMap();
+
+    // existing enr, changed status
+    bucket.updateStatus(nodeId1, EntryStatus.Disconnected);
+    expectCorrectNodeIdMap();
+  });
+
+  it("update", () => {
+    // strange node id
+    const newEnr = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    bucket.update(newEnr, EntryStatus.Connected);
+    expectCorrectNodeIdMap();
+
+    // pending
+    bucket.addPending(newEnr, EntryStatus.Connected);
+    bucket.update(newEnr, EntryStatus.Disconnected);
+    expect(bucket.getWithPending(newEnr.nodeId)?.value).to.be.equal(newEnr);
+    expectCorrectNodeIdMap();
+
+    // existing enr, unchanged status
+    bucket.update(enr1, EntryStatus.Connected);
+    expectCorrectNodeIdMap();
+
+    // existing enr, changed status
+    bucket.update(enr1, EntryStatus.Disconnected);
+    expectCorrectNodeIdMap();
+  });
+
+  it("addPending", () => {
+    // not full
+    const newEnr = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    expect(bucket.addPending(newEnr, EntryStatus.Connected)).to.be.true;
+    expect(bucket.getWithPending(newEnr.nodeId)?.value).to.be.equal(newEnr);
+
+    // full
+    const newEnr2 = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    expect(bucket.addPending(newEnr2, EntryStatus.Connected)).to.be.false;
+    expect(bucket.getWithPending(newEnr2.nodeId)?.value).to.be.undefined;
+  });
+
+  it("applyPending", () => {
+    const newEnr = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    expect(bucket.addPending(newEnr, EntryStatus.Connected)).to.be.true;
+
+    // there is 1 disconnected enr, applyPending should work
+    expect(bucket.getValue(nodeId0)).to.be.equal(enr0);
+    bucket.applyPending();
+    expect(bucket.getValue(newEnr.nodeId)).to.be.equal(newEnr);
+    expect(bucket.getValue(nodeId0)).to.be.undefined;
+  });
+
+  it("removeByIndex", () => {
+    bucket.removeByIndex(1);
+    expect(bucket.getValue(nodeId0)).to.be.equal(enr0);
+    expect(bucket.getValue(nodeId1)).to.be.undefined;
+    expect(bucket.getValue(nodeId2)).to.be.equal(enr2);
+  });
+
+  it("removeById", () => {
+    bucket.removeById(nodeId1);
+    expect(bucket.getValue(nodeId0)).to.be.equal(enr0);
+    expect(bucket.getValue(nodeId1)).to.be.undefined;
+    expect(bucket.getValue(nodeId2)).to.be.equal(enr2);
+  });
+
+  it("remove", () => {
+    bucket.remove(enr1);
+    expect(bucket.getValue(nodeId0)).to.be.equal(enr0);
+    expect(bucket.getValue(nodeId1)).to.be.undefined;
+    expect(bucket.getValue(nodeId2)).to.be.equal(enr2);
+  });
+
+  it("values", () => {
+    expect(bucket.values()).to.be.deep.equal([enr0, enr1, enr2]);
+  });
+
+  function expectCorrectNodeIdMap(): void {
+    expect(bucket.getValue(nodeId0)).to.be.equal(enr0, "incorrect enr 0");
+    expect(bucket.getValue(nodeId1)).to.be.equal(enr1, "incorrect enr 1");
+    expect(bucket.getValue(nodeId2)).to.be.equal(enr2, "incorrect enr 2");
+  }
+});

--- a/test/perf/bucket.perf.ts
+++ b/test/perf/bucket.perf.ts
@@ -1,0 +1,40 @@
+/* eslint-env mocha */
+import {itBench} from "@dapplion/benchmark";
+import { v4 } from "../../src/enr";
+import { ENR } from "../../src/enr/enr";
+import { Bucket } from "../../src/kademlia/bucket";
+import {PENDING_TIMEOUT} from "../../src/kademlia/constants";
+import { EntryStatus } from "../../src/kademlia/types";
+
+describe("bucket", function () {
+  this.timeout(0);
+  for (const updateStatusCount of [1, 10, 100]) {
+    itBench<Bucket, Bucket>({
+      id: `find enr - ${updateStatusCount} updates`,
+      beforeEach: () => generateBucket(),
+      fn: (bucket) => {
+        for (let i = 0; i < updateStatusCount; i++) {
+          for (let j = 0; j < 16; j++) {
+            const entry = bucket.getByIndex(j);
+            bucket.update(entry.value, entry.status === EntryStatus.Connected ? EntryStatus.Disconnected : EntryStatus.Connected);
+          }
+        }
+        bucket.getValue(bucket.getByIndex(15).value.nodeId);
+      },
+    });
+  }
+});
+
+function generateBucket(): Bucket {
+  // same kademlia config
+  const bucket = new Bucket(16, PENDING_TIMEOUT);
+  for (let i = 0; i < 8; i++) {
+    const enr = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    bucket.addDisconnected(enr);
+  }
+  for (let i = 8; i < 16; i++) {
+    const enr = ENR.createV4(v4.publicKey(v4.createPrivateKey()));
+    bucket.addConnected(enr);
+  }
+  return bucket;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,10 +259,10 @@
   dependencies:
     event-target-shim "^5.0.0"
 
-"@dapplion/benchmark@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@dapplion/benchmark/-/benchmark-0.1.6.tgz#d58cc150732a2d743089b9462cdfef9339ef81fa"
-  integrity sha512-qBNXvktHxqnfql2dtjdYqPVj+6OZriuKYNB/ZOdZv58kov9/vEVxFstlXQKCnmxVgC3q4NNmvWXIemTAPZah/A==
+"@dapplion/benchmark@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@dapplion/benchmark/-/benchmark-0.2.2.tgz#cc9c78e5b8d2d04311bcf30cbc4c67783e2efc6f"
+  integrity sha512-1wkplmCOVo5U3vv6Vej9MkQ1KtWtTT7WIpwVKyZdNIPnLHG82X4JwySuaaXeAKwiMs0kQzE/+ax5gNwsfqqYpQ==
   dependencies:
     "@actions/cache" "^1.0.7"
     "@actions/github" "^5.0.0"
@@ -270,7 +270,7 @@
     aws-sdk "^2.932.0"
     csv-parse "^4.16.0"
     csv-stringify "^5.6.2"
-    yargs "^17.0.1"
+    yargs "^17.1.1"
 
 "@multiformats/base-x@^4.0.1":
   version "4.0.1"
@@ -3863,10 +3863,10 @@ yargs@^13.2.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.0.1.tgz#6a1ced4ed5ee0b388010ba9fd67af83b9362e0bb"
-  integrity sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==
+yargs@^17.1.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
**Motivation**
+ Issue #145 shows that there's a performance issue searching for enr by node id

**Description**
+ Index bucket by node id, similar to forkchoice
+ When we want to find enr by node id, just find the index `this.bucketIndices` first
+ The benchmark shows that it's 9x better even we have to update the index frequently. Updating the map is still way faster than extracting node id from enr
+ Add unit tests

part of #145