### PR TITLE
Bound AddrVotes data structures

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,6 +12,10 @@ export type IDiscv5Config = ISessionConfig &
      * Whether to enable enr auto-updating
      */
     enrUpdate: boolean;
+    /**
+     * The minimum number of peer's who agree on an external IP port before updating the local ENR.
+     */
+    addrVotesToUpdateEnr: number;
   };
 
 export const defaultConfig: IDiscv5Config = {
@@ -19,6 +23,7 @@ export const defaultConfig: IDiscv5Config = {
   requestRetries: 1,
   sessionTimeout: 86400 * 1000, // 1 day
   sessionEstablishTimeout: 15 * 1000,
+  addrVotesToUpdateEnr: 10,
   lookupParallelism: 3,
   lookupRequestLimit: 3,
   lookupNumResults: 16,

--- a/src/service/addrVotes.ts
+++ b/src/service/addrVotes.ts
@@ -1,64 +1,68 @@
-import { Multiaddr } from "multiaddr";
-
+import isIp from "is-ip";
 import { NodeId } from "../enr";
-import { TimeoutMap } from "../util";
-import { IP_VOTE_TIMEOUT } from "./constants";
+
+type MultiaddrStr = string;
+
+const MAX_VOTES = 200;
 
 export class AddrVotes {
-  private votes: TimeoutMap<NodeId, string>;
-  private tallies: Record<string, number>;
+  /** Bounded by `MAX_VOTES`, on new votes evicts the oldest votes */
+  private readonly votes = new Map<NodeId, { multiaddrStr: MultiaddrStr; unixTsMs: number }>();
+  /** Bounded by votes, if the vote count of some `MultiaddrStr` reaches 0, its key is deleted */
+  private readonly tallies = new Map<MultiaddrStr, number>();
 
-  constructor() {
-    this.votes = new TimeoutMap(IP_VOTE_TIMEOUT, this.removeVote);
-    this.tallies = {};
-  }
+  constructor(private readonly addrVotesToUpdateEnr: number) {}
 
-  addVote(voter: NodeId, addr: Multiaddr): void {
-    const addrStr = addr.toString();
-    this.votes.set(voter, addrStr);
-    this.addTally(addrStr);
-  }
+  /**
+   * Adds vote to a given `recipientIp` and `recipientPort`. If the votes for this addr are greater than `votesToWin`,
+   * this function returns the winning `multiaddrStr` and clears existing votes, restarting the process.
+   */
+  addVote(
+    voter: NodeId,
+    { recipientIp, recipientPort }: { recipientIp: string; recipientPort: number }
+  ): { multiaddrStr: string } | undefined {
+    const multiaddrStr = `/${isIp.v4(recipientIp) ? "ip4" : "ip6"}/${recipientIp}/udp/${recipientPort}`;
 
-  removeVote(voter: NodeId): void {
-    if (this.votes.delete(voter)) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.removeTally(this.votes.get(voter)!);
+    const prevVote = this.votes.get(voter);
+    if (prevVote?.multiaddrStr === multiaddrStr) {
+      // Same vote, ignore
+      return;
+    } else if (prevVote !== undefined) {
+      // If there was a previous vote, remove from tally
+      const prevVoteTally = (this.tallies.get(prevVote.multiaddrStr) ?? 0) - 1;
+      if (prevVoteTally <= 0) {
+        this.tallies.delete(prevVote.multiaddrStr);
+      } else {
+        this.tallies.set(prevVote.multiaddrStr, prevVoteTally);
+      }
     }
-  }
 
-  addTally(addrStr: string): void {
-    if (!this.tallies[addrStr]) {
-      this.tallies[addrStr] = 0;
+    const currentTally = (this.tallies.get(multiaddrStr) ?? 0) + 1;
+
+    // Conclude vote period if there are enough votes for an option
+    if (currentTally >= this.addrVotesToUpdateEnr) {
+      // If enough peers vote on the same multiaddrStr conclude the vote
+      this.clear();
+      return { multiaddrStr };
     }
-    this.tallies[addrStr] += 1;
+
+    // Persist vote
+    this.tallies.set(multiaddrStr, currentTally);
+    this.votes.set(voter, { multiaddrStr, unixTsMs: Date.now() });
+
+    // If there are too many votes, remove the oldest
+    if (this.votes.size > MAX_VOTES) {
+      for (const vote of this.votes.keys()) {
+        this.votes.delete(vote);
+        if (this.votes.size <= MAX_VOTES) {
+          break;
+        }
+      }
+    }
   }
 
   clear(): void {
     this.votes.clear();
-    this.tallies = {};
+    this.tallies.clear();
   }
-
-  best(tiebreaker?: Multiaddr): Multiaddr | undefined {
-    if (!tiebreaker) {
-      if (!this.votes.size) {
-        return undefined;
-      }
-      tiebreaker = new Multiaddr(Object.keys(this.tallies)[0]);
-    }
-    const tiebreakerStr = tiebreaker.toString();
-    let best: [string, number] = [tiebreakerStr, this.tallies[tiebreakerStr] ?? 0];
-    for (const [addrStr, total] of Object.entries(this.tallies)) {
-      if (total > best[1]) {
-        best = [addrStr, total];
-      }
-    }
-    return new Multiaddr(best[0]);
-  }
-
-  private removeTally = (addrStr: string): void => {
-    const total = this.tallies[addrStr];
-    if (!isNaN(total)) {
-      this.tallies[addrStr] = total - 1;
-    }
-  };
 }

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from "events";
 import debug from "debug";
 import { randomBytes } from "libp2p-crypto";
 import { Multiaddr } from "multiaddr";
-import isIp = require("is-ip");
 import PeerId from "peer-id";
 
 import { UDPTransportService } from "../transport";
@@ -147,7 +146,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
     this.activeNodesResponses = new Map();
     this.connectedPeers = new Map();
     this.nextLookupId = 1;
-    this.addrVotes = new AddrVotes();
+    this.addrVotes = new AddrVotes(config.addrVotesToUpdateEnr);
     if (metrics) {
       this.metrics = metrics;
       // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -656,16 +655,11 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
       return;
     }
     if (this.config.enrUpdate) {
-      this.addrVotes.addVote(
-        srcId,
-        new Multiaddr(
-          `/${isIp.v4(message.recipientIp) ? "ip4" : "ip6"}/${message.recipientIp}/udp/${message.recipientPort}`
-        )
-      );
+      const winningVote = this.addrVotes.addVote(srcId, message);
       const currentAddr = this.enr.getLocationMultiaddr("udp");
-      const votedAddr = this.addrVotes.best(currentAddr);
-      if ((currentAddr && votedAddr && !votedAddr.equals(currentAddr)) || (!currentAddr && votedAddr)) {
-        log("Local ENR (IP & UDP) updated: %s", votedAddr);
+      if (winningVote && (!currentAddr || winningVote.multiaddrStr !== currentAddr.toString())) {
+        log("Local ENR (IP & UDP) updated: %s", winningVote.multiaddrStr);
+        const votedAddr = new Multiaddr(winningVote.multiaddrStr);
         this.enr.setLocationMultiaddr(votedAddr);
         this.emit("multiaddrUpdated", votedAddr);
       }

--- a/test/service/addrVotes.test.ts
+++ b/test/service/addrVotes.test.ts
@@ -1,0 +1,48 @@
+import { expect } from "chai";
+import { Multiaddr } from "multiaddr";
+import { createNodeId } from "../../src/enr";
+import {AddrVotes} from "../../src/service/addrVotes";
+
+describe("AddrVotes", () => {
+  let addVotes: AddrVotes;
+
+  beforeEach(() => {
+    addVotes = new AddrVotes(3);
+  });
+
+  it("should return winning vote after 3 same votes", () => {
+    const recipientIp = "127.0.0.1";
+    const recipientPort = 30303;
+    const multi0 = new Multiaddr(`/ip4/${recipientIp}/udp/${recipientPort}`);
+    const nodeId = createNodeId(Buffer.alloc(32));
+    const vote = {recipientIp, recipientPort};
+    expect(addVotes.addVote(nodeId, vote)).to.be.undefined;
+    // same vote, no effect
+    for (let i = 0; i < 100; i++) {
+      expect(addVotes.addVote(nodeId, vote)).to.be.undefined;
+    }
+    // 1 more vote, return undefined
+    expect(addVotes.addVote(createNodeId(Buffer.alloc(32, 2)), vote)).to.be.undefined;
+    // winning vote
+    const winningVote = addVotes.addVote(createNodeId(Buffer.alloc(32, 3)), vote);
+    expect(winningVote?.multiaddrStr).to.be.equal(multi0.toString(), "incorrect winning vote");
+  });
+
+  it("1 node adds 2 different vote", () => {
+    const recipientIp = "127.0.0.1";
+    const recipientPort = 30303;
+    const multi0 = new Multiaddr(`/ip4/${recipientIp}/udp/${recipientPort}`);
+    const nodeId = createNodeId(Buffer.alloc(32));
+    const vote = {recipientIp, recipientPort};
+    expect(addVotes.addVote(nodeId, vote)).to.be.undefined;
+    // new vote, strange one => 1st vote is deleted
+    expect(addVotes.addVote(nodeId, {...vote, recipientPort: 30304})).to.be.undefined;
+
+    // need 3 more votes to win
+    expect(addVotes.addVote(createNodeId(Buffer.alloc(32, 1)), vote)).to.be.undefined;
+    expect(addVotes.addVote(createNodeId(Buffer.alloc(32, 2)), vote)).to.be.undefined;
+    // winning vote
+    const winningVote = addVotes.addVote(createNodeId(Buffer.alloc(32, 3)), vote);
+    expect(winningVote?.multiaddrStr).to.be.equal(multi0.toString(), "incorrect winning vote");
+  });
+});


### PR DESCRIPTION
**Motivation**
+ Start from @dapplion bound AddrVotes data structures which make it simple to find a winning vote
+ When there is enough vote configured by `addrVotesToUpdateEnr` (10 by default), the `addVote()` api returns the winning vote
+ If there are more than `MAX_VOTES` (200), remove the oldest

**Description**
Since this is a new implementation of address vote, this should close #150