### PR TITLE
fix: add toNewUint8Array when decoding enr values

### DIFF
--- a/src/enr/enr.ts
+++ b/src/enr/enr.ts
@@ -128,7 +128,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
   get ip(): string | undefined {
     const raw = this.get("ip");
     if (raw) {
-      return muConvert.toString(protocols.names.ip4.code, raw) as string;
+      return muConvert.toString(protocols.names.ip4.code, toNewUint8Array(raw)) as string;
     } else {
       return undefined;
     }
@@ -179,7 +179,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
   get ip6(): string | undefined {
     const raw = this.get("ip6");
     if (raw) {
-      return muConvert.toString(protocols.names.ip6.code, raw) as string;
+      return muConvert.toString(protocols.names.ip6.code, toNewUint8Array(raw)) as string;
     } else {
       return undefined;
     }
@@ -196,7 +196,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
   get tcp6(): number | undefined {
     const raw = this.get("tcp6");
     if (raw) {
-      return Number(muConvert.toString(protocols.names.tcp.code, raw));
+      return Number(muConvert.toString(protocols.names.tcp.code, toNewUint8Array(raw)));
     } else {
       return undefined;
     }
@@ -213,7 +213,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
   get udp6(): number | undefined {
     const raw = this.get("udp6");
     if (raw) {
-      return Number(muConvert.toString(protocols.names.udp.code, raw));
+      return Number(muConvert.toString(protocols.names.udp.code, toNewUint8Array(raw)));
     } else {
       return undefined;
     }

--- a/src/message/decode.ts
+++ b/src/message/decode.ts
@@ -17,6 +17,7 @@ import {
   ITalkRespMessage,
 } from "./types";
 import { ENR } from "../enr";
+import { toNewUint8Array } from "../util";
 
 const ERR_INVALID_MESSAGE = "invalid message";
 
@@ -65,7 +66,8 @@ function decodePong(data: Buffer): IPongMessage {
   if (!Array.isArray(rlpRaw) || rlpRaw.length !== 4) {
     throw new Error(ERR_INVALID_MESSAGE);
   }
-  let stringIpAddr = ipBufferToString(rlpRaw[2]);
+  let stringIpAddr = ipBufferToString(toNewUint8Array(rlpRaw[2]));
+  // let stringIpAddr = ipBufferToString(rlpRaw[2]);
   const parsedIp = ip6addr.parse(stringIpAddr);
   if (parsedIp.kind() === "ipv4") {
     stringIpAddr = parsedIp.toString({ format: "v4" });

--- a/test/unit/enr/enr.test.ts
+++ b/test/unit/enr/enr.test.ts
@@ -30,6 +30,16 @@ describe("ENR", function () {
       expect(toHex(eth2)).to.be.equal("f6775d0700000113ffffffffffff1f00");
     });
 
+    it("should encodeTxt and decodeTxt ipv6 enr successfully", async () => {
+      const peerId = await PeerId.create({ keyType: "secp256k1" });
+      const enr = ENR.createFromPeerId(peerId);
+      enr.setLocationMultiaddr(new Multiaddr("/ip6/aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa/udp/9000"));
+      const keypair = createKeypairFromPeerId(peerId);
+      const enr2 = ENR.decodeTxt(enr.encodeTxt(keypair.privateKey));
+      expect(enr2.udp6).to.equal(9000);
+      expect(enr2.ip6).to.equal('aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa');
+    });
+
     it("should throw error - no id", () => {
       try {
         const txt = Buffer.from(

--- a/test/unit/message/codec.test.ts
+++ b/test/unit/message/codec.test.ts
@@ -35,6 +35,16 @@ describe("message", () => {
     },
     {
       message: {
+        type: MessageType.PONG,
+        id: 1n,
+        enrSeq: 1n,
+        recipientIp: "aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa",
+        recipientPort: 5000,
+      },
+      expected: Buffer.from("02d6010190aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa821388", "hex"),
+    },
+    {
+      message: {
         type: MessageType.FINDNODE,
         id: 1n,
         distances: [250],


### PR DESCRIPTION
There is now a problem with encoding and decoding enr addresses because `toNewUint8Array` should be called before `muConvert.toString`