### PR TITLE
chore: Bump peer-id dep to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "check-types": "tsc --noEmit",
     "build": "tsc --declaration --outDir lib",
+    "prepare": "npm run build",
     "prepublishOnly": "yarn build",
     "lint": "eslint --color --ext .ts src/",
     "test": "yarn test:unit && yarn test:e2e",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "check-types": "tsc --noEmit",
     "build": "tsc --declaration --outDir lib",
-    "prepare": "npm run build",
     "prepublishOnly": "yarn build",
     "lint": "eslint --color --ext .ts src/",
     "test": "yarn test:unit && yarn test:e2e",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "libp2p-crypto": "^0.19.7",
     "multiaddr": "^10.0.1",
     "multihashes": "^4.0.3",
-    "peer-id": "^0.15.3",
+    "peer-id": "^0.16.0",
     "rlp": "^2.2.6",
     "strict-event-emitter-types": "^2.0.0",
     "varint": "^6.0.0"


### PR DESCRIPTION
Bumping this dependency upgrades several transitive dependencies down the dependency tree (notable `libp2p/crypto` which in turn switches from the deprecated `noble-secp256k1` to the updated/namespaced `@noble/secp256k1`).  The only potentially impactful breaking change here is `peer-id` v0.16.0 requires Node v15+.  We've been using this version of `peer-id` in the `portalnetwork` module for a while now with no ill effects and I'd like to remove the deprecated `noble-secp256k1` module from our dependency tree.