### PR TITLE
fix: Remove p2p portions of multiaddr in `nodeAddressToString`

### DIFF
--- a/src/session/nodeInfo.ts
+++ b/src/session/nodeInfo.ts
@@ -11,7 +11,11 @@ export interface INodeAddress {
 }
 
 export function nodeAddressToString(nodeAddr: INodeAddress): string {
-  return nodeAddr.nodeId + ":" + Buffer.from(nodeAddr.socketAddr.bytes).toString("hex");
+  // Since `sendRPCMessage` takes an ENR or Multiaddr, remove any p2p portions of the
+  // multiaddr since only the UDP socket addr is included in the session cache
+  // key (e.g. /ip4/127.0.0.1/udp/9000/p2p/Qm...)
+  const normalizedAddr = nodeAddr.socketAddr.decapsulateCode(421);
+  return nodeAddr.nodeId + ":" + Buffer.from(normalizedAddr.bytes).toString("hex");
 }
 
 /**

--- a/src/session/nodeInfo.ts
+++ b/src/session/nodeInfo.ts
@@ -11,9 +11,9 @@ export interface INodeAddress {
 }
 
 export function nodeAddressToString(nodeAddr: INodeAddress): string {
-  // Since `sendRPCMessage` takes an ENR or Multiaddr, remove any p2p portions of the
-  // multiaddr since only the UDP socket addr is included in the session cache
-  // key (e.g. /ip4/127.0.0.1/udp/9000/p2p/Qm...)
+  // Since the Discv5 service allows a Multiaddr in outbound message handlers and requires a multiaddr input to
+  // have a peer ID specified, we remove any p2p portions of the multiaddr when generating the nodeAddressString 
+  // since only the UDP socket addr is included in the session cache key (e.g. /ip4/127.0.0.1/udp/9000/p2p/Qm...)
   const normalizedAddr = nodeAddr.socketAddr.decapsulateCode(421);
   return nodeAddr.nodeId + ":" + Buffer.from(normalizedAddr.bytes).toString("hex");
 }

--- a/src/session/nodeInfo.ts
+++ b/src/session/nodeInfo.ts
@@ -12,7 +12,7 @@ export interface INodeAddress {
 
 export function nodeAddressToString(nodeAddr: INodeAddress): string {
   // Since the Discv5 service allows a Multiaddr in outbound message handlers and requires a multiaddr input to
-  // have a peer ID specified, we remove any p2p portions of the multiaddr when generating the nodeAddressString 
+  // have a peer ID specified, we remove any p2p portions of the multiaddr when generating the nodeAddressString
   // since only the UDP socket addr is included in the session cache key (e.g. /ip4/127.0.0.1/udp/9000/p2p/Qm...)
   const normalizedAddr = nodeAddr.socketAddr.decapsulateCode(421);
   return nodeAddr.nodeId + ":" + Buffer.from(normalizedAddr.bytes).toString("hex");


### PR DESCRIPTION
The `service.sendTalkRequest` takes a `multiaddr` as an optional input (either that or ENR).  When a `multiaddr` is passed in, the `createNodeContact` method which is used internally to construct the `NodeContact` object used to retrieve the session requires that any multiAddr inputs specify the nodeId in the `/p2p/` protocol of the multiaddr.  However, the session key used to to reference individual sessions is a combination of the `nodeId` and the hex encoded bytes of just the location multiaddr for the UDP socket associated with the session.  This PR filters the p2p protocol out of the multiaddr input when constructing the session key used to retrieve a session so that this `sendTalkRequest` method now works properly.  