### PR TITLE
feat: add `packet` to package.json `exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     },
     "./libp2p": {
       "import": "./lib/libp2p/index.js"
+    },
+    "./packet": {
+      "import": "./lib/packet/index.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
Adds `packet` to the `exports` field in package.json as we're using this in Ultralight and don't seem to be able to import it properly without hacking the package.json in node_modules after install