### PR TITLE
chore: migrate to is-ip 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "dgram": "^1.0.1",
     "err-code": "^3.0.1",
     "ip6addr": "^0.2.3",
-    "is-ip": "^3.1.0",
+    "is-ip": "^4.0.0",
     "rlp": "^2.2.6",
     "strict-event-emitter-types": "^2.0.0",
     "varint": "^6.0.0"

--- a/src/message/encode.ts
+++ b/src/message/encode.ts
@@ -1,6 +1,6 @@
 import * as RLP from "rlp";
 import { multiaddr } from "@multiformats/multiaddr";
-import isIp from "is-ip";
+import { isIPv4 } from "is-ip";
 
 import {
   IPingMessage,
@@ -56,7 +56,7 @@ export function encodePingMessage(m: IPingMessage): Buffer {
 }
 
 export function encodePongMessage(m: IPongMessage): Buffer {
-  const ipMultiaddr = multiaddr(`/${isIp.v4(m.recipientIp) ? "ip4" : "ip6"}/${m.recipientIp}`);
+  const ipMultiaddr = multiaddr(`/${isIPv4(m.recipientIp) ? "ip4" : "ip6"}/${m.recipientIp}`);
   const tuple = ipMultiaddr.tuples()[0][1];
   if (!tuple) {
     throw new Error("invalid address for encoding");

--- a/src/service/addrVotes.ts
+++ b/src/service/addrVotes.ts
@@ -1,4 +1,4 @@
-import isIp from "is-ip";
+import { isIPv4 } from "is-ip";
 import { NodeId } from "../enr/index.js";
 
 type MultiaddrStr = string;
@@ -21,7 +21,7 @@ export class AddrVotes {
     voter: NodeId,
     { recipientIp, recipientPort }: { recipientIp: string; recipientPort: number }
   ): { multiaddrStr: string } | undefined {
-    const multiaddrStr = `/${isIp.v4(recipientIp) ? "ip4" : "ip6"}/${recipientIp}/udp/${recipientPort}`;
+    const multiaddrStr = `/${isIPv4(recipientIp) ? "ip4" : "ip6"}/${recipientIp}/udp/${recipientPort}`;
 
     const prevVote = this.votes.get(voter);
     if (prevVote?.multiaddrStr === multiaddrStr) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,11 +2382,6 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==
 
-ip-regex@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
-  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
-
 ip-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-5.0.0.tgz#cd313b2ae9c80c07bd3851e12bf4fa4dc5480632"
@@ -2483,12 +2478,12 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-ip@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
-  integrity sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==
+is-ip@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-4.0.0.tgz#8e9eae12056bf46edafad19054dcc3666a324b3a"
+  integrity sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==
   dependencies:
-    ip-regex "^4.0.0"
+    ip-regex "^5.0.0"
 
 is-ip@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
**Motivation**
- Majority of modules in lodestar goes with the last performant version of `is-ip` which is 4.0.0
- `v4.0.0` is a breaking change, this gives lodestar a chance to enforce `is-ip@4.0.0` to avoid the performance issue in v5.0.0

**Description**
Migrate `is-ip` to v4.0.0