### PR TITLE
chore: disable validateSingleCommit

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,5 +20,6 @@ jobs:
             fix
             feat
             chore
-          validateSingleCommit: true #single commit can ovveride squash merge commit message
+          # Discv5 repo uses https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/
+          validateSingleCommit: false
           validateSingleCommitMatchesPrTitle: false


### PR DESCRIPTION
Discv5 repo uses https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/