### PR TITLE
fix: add more checks to handleFindNode

### DIFF
--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -743,7 +743,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
     for (const distance of new Set(distances)) {
       // filter out invalid distances
       if (distance < 0 || distance > 256) {
-        return;
+        continue;
       }
       // if the distance is 0, send our local ENR
       if (distance === 0) {

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -740,8 +740,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
   private handleFindNode(nodeAddr: INodeAddress, message: IFindNodeMessage): void {
     const { id, distances } = message;
     let nodes: ENR[] = [];
-    let distinctDistances = distances.filter((n, i) => distances.indexOf(n) === i);
-    distinctDistances.forEach((distance) => {
+    for (const distance of new Set(distances)) {
       // filter out invalid distances
       if (distance < 0 || distance > 256) {
         return;
@@ -753,7 +752,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
       } else {
         nodes.push(...this.kbuckets.valuesOfDistance(distance));
       }
-    });
+    }
     // limit response to 16 nodes
     nodes = nodes.slice(0, 16);
     if (nodes.length === 0) {


### PR DESCRIPTION
This PR fixes a few things in the FINDNODE request handler:

* We should filter out invalid/duplicate distances.
* According to [the spec](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#findnode-request-0x03), the recommended result limit is 16, not 15.
* When returning an empty response, `total` should be one.