### PR TITLE
fix: throw error when encoding/decoding PONG with invalid port

### DIFF
--- a/src/message/decode.ts
+++ b/src/message/decode.ts
@@ -67,10 +67,13 @@ function decodePong(data: Buffer): IPongMessage {
     throw new Error(ERR_INVALID_MESSAGE);
   }
   let stringIpAddr = convertToString("ip4", toNewUint8Array(rlpRaw[2]));
-  // let stringIpAddr = ipBufferToString(rlpRaw[2]);
   const parsedIp = ip6addr.parse(stringIpAddr);
   if (parsedIp.kind() === "ipv4") {
     stringIpAddr = parsedIp.toString({ format: "v4" });
+  }
+  // recipientPort is a uint16 (2 bytes)
+  if (rlpRaw[3].length > 2) {
+    throw new Error(ERR_INVALID_MESSAGE);
   }
   return {
     type: MessageType.PONG,

--- a/src/message/encode.ts
+++ b/src/message/encode.ts
@@ -61,6 +61,9 @@ export function encodePongMessage(m: IPongMessage): Buffer {
   if (!tuple) {
     throw new Error("invalid address for encoding");
   }
+  if (m.recipientPort < 0 || m.recipientPort > 65535) {
+    throw new Error("invalid port for encoding");
+  }
   return Buffer.concat([
     Buffer.from([MessageType.PONG]),
     RLP.encode([toBuffer(m.id), toBuffer(m.enrSeq), tuple, m.recipientPort]),


### PR DESCRIPTION
According to [the spec](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#pong-response-0x02), `recipient-port` is an (unsigned) 16-bit integer. This PR ensures that those port values are valid.

* Remove a commented out line of code, doesn't seem useful to keep.
* When decoding, check that the length of the field isn't greater than 2 bytes.
* When encoding, check that the number is in the valid port range.
* Add a test for encoding a PONG message with a 1-byte port.
* Add a new test function that handles invalid messages.