### PR TITLE
feat: limit nodes response to 16 packets

### DIFF
--- a/src/session/constants.ts
+++ b/src/session/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_NODES_TOTAL_PACKETS = 16;

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -42,6 +42,7 @@ import { getNodeAddress, INodeAddress, INodeContactType, nodeAddressToString, No
 import LRUCache from "lru-cache";
 import { TimeoutMap } from "../util/index.js";
 import { IDiscv5Metrics } from "../service/types.js";
+import { MAX_NODES_TOTAL_PACKETS } from "./constants.js";
 
 const log = debug("discv5:sessionService");
 
@@ -701,8 +702,13 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
       if (response.total > 1) {
         // This is a multi-response Nodes response
         if (requestCall.remainingResponses === undefined) {
-          // This is the first nodes response
-          requestCall.remainingResponses = response.total - 1;
+          if (response.total > MAX_NODES_TOTAL_PACKETS) {
+            log("Will ignore some packets, total: %d", response.total);
+            return;
+          }
+          // This is the first nodes response, initialize & decrement
+          requestCall.remainingResponses = Math.min(response.total, MAX_NODES_TOTAL_PACKETS);
+          requestCall.remainingResponses--;
           // add back the request and send the response
           this.activeRequests.set(nodeAddrStr, requestCall);
           this.emit("response", nodeAddr, response);


### PR DESCRIPTION
According to [the spec](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire.md#nodes-response-0x04):

> Implementations may place a limit on the allowed maximum for total. If exceeded, additional responses may be ignored.

This PR implements this feature. It will ignore response packets after `MAX_NODES_TOTAL_PACKETS` (16). This should be more than enough, considering the FINDNODE request handler should limit the result to 16 nodes, which can be fit into 6 packets if packed correctly.