### PR TITLE
Ignore excess packets instead of rejecting whole response

### DIFF
--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -704,7 +704,6 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
         if (requestCall.remainingResponses === undefined) {
           if (response.total > MAX_NODES_TOTAL_PACKETS) {
             log("Will ignore some packets, total: %d", response.total);
-            return;
           }
           // This is the first nodes response, initialize & decrement
           requestCall.remainingResponses = Math.min(response.total, MAX_NODES_TOTAL_PACKETS);


### PR DESCRIPTION
I was reviewing my changes again and noticed that I made a mistake. This return statement shouldn't exist. My bad.

The purpose of that code block was to provide some message to the user.

It's not an urgent issue because peers really shouldn't send more than 16 packets anyway.

Also, I learned that you guys did check `total` just later than I would have expected. I think it's okay to have both checks.

https://github.com/ChainSafe/discv5/blob/f2cc802fd7fb65c5fddfa4d375f9ac58b2af13f9/src/service/service.ts#L849-L856