### PR TITLE
fix: revert limit to nodes response

### DIFF
--- a/src/session/constants.ts
+++ b/src/session/constants.ts
@@ -1,1 +1,0 @@
-export const MAX_NODES_TOTAL_PACKETS = 16;

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -42,7 +42,6 @@ import { getNodeAddress, INodeAddress, INodeContactType, nodeAddressToString, No
 import LRUCache from "lru-cache";
 import { TimeoutMap } from "../util/index.js";
 import { IDiscv5Metrics } from "../service/types.js";
-import { MAX_NODES_TOTAL_PACKETS } from "./constants.js";
 
 const log = debug("discv5:sessionService");
 
@@ -702,13 +701,8 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
       if (response.total > 1) {
         // This is a multi-response Nodes response
         if (requestCall.remainingResponses === undefined) {
-          if (response.total > MAX_NODES_TOTAL_PACKETS) {
-            log("Will ignore some packets, total: %d", response.total);
-            return;
-          }
-          // This is the first nodes response, initialize & decrement
-          requestCall.remainingResponses = Math.min(response.total, MAX_NODES_TOTAL_PACKETS);
-          requestCall.remainingResponses--;
+          // This is the first nodes response
+          requestCall.remainingResponses = response.total - 1;
           // add back the request and send the response
           this.activeRequests.set(nodeAddrStr, requestCall);
           this.emit("response", nodeAddr, response);


### PR DESCRIPTION
My PR from yesterday was a mistake. I thought it was handling the nodes response, but it was handling the nodes response *request*. So the original version works just fine. My bad, sorry about that.

And that feature I added already existed, here:

https://github.com/ChainSafe/discv5/blob/f2cc802fd7fb65c5fddfa4d375f9ac58b2af13f9/src/service/service.ts#L849-L856

Associated with #219.