### PR TITLE
fix: ensure our enr has signature in INodesMessage response

### DIFF
--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -790,7 +790,10 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
       }
       // if the distance is 0, send our local ENR
       if (distance === 0) {
-        this.enr.encodeToValues(this.keypair.privateKey);
+        // ensure our enr has signature before sending response
+        if (!this.enr.signature) {
+          this.enr.encodeToValues(this.keypair.privateKey);
+        }
         nodes.push(this.enr);
       } else {
         nodes.push(...this.kbuckets.valuesOfDistance(distance));


### PR DESCRIPTION
**Motivation**
- When handling FindNodes request, if distance is 0 we always call `this.enr.encodeToValues(privateKey)` which sign the enr content, this is to make sure we have a signature in our enr
- I debug a node running several days, the `seq` in enr is only 11n, it means that there are not a lot of modification that cause us to sign the enr

**Description**
- Check signature before calling `this.enr.encodeToValues`
- Add more comments

this could be related to #201