### PR TITLE
fix: delete signature on enr.delete

### DIFF
--- a/src/enr/enr.ts
+++ b/src/enr/enr.ts
@@ -92,6 +92,14 @@ export class ENR extends Map<ENRKey, ENRValue> {
     }
     return super.set(k, v);
   }
+  delete(k: ENRKey): boolean {
+    this.signature = null;
+    this.seq++;
+    if (k === "secp256k1" && this.id === "v4") {
+      delete this._nodeId;
+    }
+    return super.delete(k);
+  }
   get id(): string {
     const id = this.get("id") as Buffer;
     if (!id) throw new Error("id not found.");

--- a/test/unit/enr.test.ts
+++ b/test/unit/enr.test.ts
@@ -93,6 +93,19 @@ describe("ENR Multiformats support", () => {
     expect(record.get("tcp")).to.deep.equal(tuples1[1][1]);
   });
 
+  it("should properly handle enr key set", () => {
+    record.encode(privateKey);
+    record.set("tcp", Uint8Array.from([0, 1]));
+    expect(() => record.encode()).to.throw();
+  });
+
+  it("should properly handle enr key delete", () => {
+    record.set("tcp", Uint8Array.from([0, 1]));
+    record.encode(privateKey);
+    record.delete("tcp");
+    expect(() => record.encode()).to.throw();
+  });
+
   describe("location multiaddr", async () => {
     const ip4 = "127.0.0.1";
     const ip6 = "::1";


### PR DESCRIPTION
The cached signature should be deleted when enr keys are deleted.
Otherwise, when the enr is serialized, it will write an invalid signature instead of requiring a new signature to be crafted.