### PR TITLE
feat!: add IPv6 support

### DIFF
--- a/src/libp2p/discv5.ts
+++ b/src/libp2p/discv5.ts
@@ -8,6 +8,7 @@ import { Discv5, ENRInput, SignableENRInput } from "../service/index.js";
 import { ENR } from "../enr/index.js";
 import { IDiscv5Config } from "../config/index.js";
 import { MetricsRegister } from "../metrics.js";
+import { BindAddrs } from "../transport/types.js";
 
 // Default to 0ms between automatic searches
 // 0ms is 'backwards compatible' with the prior behavior (always be searching)
@@ -75,7 +76,7 @@ export class Discv5Discovery extends EventEmitter<PeerDiscoveryEvents> implement
       bindAddrs: {
         ip4: options.bindAddrs.ip4 ? multiaddr(options.bindAddrs.ip4) : undefined,
         ip6: options.bindAddrs.ip6 ? multiaddr(options.bindAddrs.ip6) : undefined,
-      },
+      } as BindAddrs,
       config: options,
       metricsRegistry: options.metricsRegistry,
     });

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -4,7 +4,7 @@ import { randomBytes } from "@libp2p/crypto";
 import { Multiaddr } from "@multiformats/multiaddr";
 import { PeerId } from "@libp2p/interface-peer-id";
 
-import { IPMode, ITransportService, UDPTransportService } from "../transport/index.js";
+import { BindAddrs, IPMode, ITransportService, UDPTransportService } from "../transport/index.js";
 import { MAX_PACKET_SIZE } from "../packet/index.js";
 import { ConnectionDirection, RequestErrorType, SessionService } from "../session/index.js";
 import { ENR, NodeId, MAX_RECORD_SIZE, createNodeId, SignableENR } from "../enr/index.js";
@@ -81,10 +81,7 @@ const log = debug("discv5:service");
 export interface IDiscv5CreateOptions {
   enr: SignableENRInput;
   peerId: PeerId;
-  bindAddrs: {
-    ip4?: Multiaddr;
-    ip6?: Multiaddr;
-  };
+  bindAddrs: BindAddrs;
   config?: Partial<IDiscv5Config>;
   metricsRegistry?: MetricsRegister | null;
   transport?: ITransportService;
@@ -215,7 +212,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
       fullConfig,
       decodedEnr,
       keypair,
-      transport ?? new UDPTransportService({ ...bindAddrs, nodeId: decodedEnr.nodeId, rateLimiter })
+      transport ?? new UDPTransportService({ bindAddrs, nodeId: decodedEnr.nodeId, rateLimiter })
     );
     return new Discv5(fullConfig, sessionService, metrics);
   }

--- a/src/session/nodeInfo.ts
+++ b/src/session/nodeInfo.ts
@@ -2,6 +2,8 @@ import { Multiaddr, isMultiaddr } from "@multiformats/multiaddr";
 import { peerIdFromString } from "@libp2p/peer-id";
 import { createKeypairFromPeerId, IKeypair } from "../keypair/index.js";
 import { ENR, NodeId, v4 } from "../enr/index.js";
+import { IPMode } from "../transport/types.js";
+import { getSocketAddressMultiaddrOnENR } from "../util/ip.js";
 
 /** A representation of an unsigned contactable node. */
 export interface INodeAddress {
@@ -88,10 +90,10 @@ export function getNodeId(contact: NodeContact): NodeId {
   }
 }
 
-export function getNodeAddress(contact: NodeContact): INodeAddress {
+export function getNodeAddress(contact: NodeContact, ipMode: IPMode): INodeAddress {
   switch (contact.type) {
     case INodeContactType.ENR: {
-      const socketAddr = contact.enr.getLocationMultiaddr("udp");
+      const socketAddr = getSocketAddressMultiaddrOnENR(contact.enr, ipMode);
       if (!socketAddr) {
         throw new Error("ENR has no udp multiaddr");
       }

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -3,7 +3,7 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import debug from "debug";
 import { Multiaddr } from "@multiformats/multiaddr";
 
-import { ITransportService } from "../transport/index.js";
+import { IPMode, ITransportService } from "../transport/index.js";
 import {
   PacketType,
   IPacket,
@@ -42,6 +42,7 @@ import { getNodeAddress, INodeAddress, INodeContactType, nodeAddressToString, No
 import LRUCache from "lru-cache";
 import { TimeoutMap } from "../util/index.js";
 import { IDiscv5Metrics } from "../metrics.js";
+import { getSocketAddressMultiaddrOnENR } from "../util/ip.js";
 
 const log = debug("discv5:sessionService");
 
@@ -134,6 +135,8 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    */
   private sessions: LRUCache<NodeAddressString, Session>;
 
+  private ipMode: IPMode;
+
   constructor(config: ISessionConfig, enr: SignableENR, keypair: IKeypair, transport: ITransportService) {
     super();
 
@@ -147,12 +150,13 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
     this.transport = transport;
 
     this.activeRequests = new TimeoutMap(config.requestTimeout, (k, v) =>
-      this.handleRequestTimeout(getNodeAddress(v.contact), v)
+      this.handleRequestTimeout(getNodeAddress(v.contact, this.ipMode), v)
     );
     this.activeRequestsNonceMapping = new Map();
     this.pendingRequests = new Map();
     this.activeChallenges = new LRUCache({ maxAge: config.requestTimeout * 2 });
     this.sessions = new LRUCache({ maxAge: config.sessionTimeout, max: config.sessionCacheCapacity });
+    this.ipMode = this.transport.ipMode;
   }
 
   /**
@@ -186,10 +190,10 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    * Sends an RequestMessage to a node.
    */
   public sendRequest(contact: NodeContact, request: RequestMessage): void {
-    const nodeAddr = getNodeAddress(contact);
+    const nodeAddr = getNodeAddress(contact, this.ipMode);
     const nodeAddrStr = nodeAddressToString(nodeAddr);
 
-    if (nodeAddr.socketAddr.equals(this.transport.multiaddr)) {
+    if (this.transport.bindAddrs.some((bindAddr) => nodeAddr.socketAddr.equals(bindAddr))) {
       log("Filtered request to self");
       return;
     }
@@ -482,8 +486,12 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    * Returns true if they match
    */
   private verifyEnr(enr: ENR, nodeAddr: INodeAddress): boolean {
-    const enrMultiaddr = enr.getLocationMultiaddr("udp");
-    return enr.nodeId === nodeAddr.nodeId && (enrMultiaddr?.equals(nodeAddr.socketAddr) ?? true);
+    const enrMultiaddrIP4 = getSocketAddressMultiaddrOnENR(enr, { ...this.ipMode, ip6: false });
+    const enrMultiaddrIP6 = getSocketAddressMultiaddrOnENR(enr, { ...this.ipMode, ip4: false });
+    return (
+      enr.nodeId === nodeAddr.nodeId &&
+      (enrMultiaddrIP4?.equals(nodeAddr.socketAddr) ?? enrMultiaddrIP6?.equals(nodeAddr.socketAddr) ?? true)
+    );
   }
 
   /** Handle a message that contains an authentication header */
@@ -737,7 +745,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    * Inserts a request and associated authTag mapping
    */
   private insertActiveRequest(requestCall: IRequestCall): void {
-    const nodeAddr = getNodeAddress(requestCall.contact);
+    const nodeAddr = getNodeAddress(requestCall.contact, this.ipMode);
     const nodeAddrStr = nodeAddressToString(nodeAddr);
     this.activeRequestsNonceMapping.set(requestCall.packet.header.nonce.toString("hex"), nodeAddr);
     this.activeRequests.set(nodeAddrStr, requestCall);
@@ -815,7 +823,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
     // Fail the current request
     this.emit("requestFailed", requestCall.request.id, error);
 
-    const nodeAddr = getNodeAddress(requestCall.contact);
+    const nodeAddr = getNodeAddress(requestCall.contact, this.ipMode);
     this.failSession(nodeAddr, error, removeSession);
   }
 

--- a/src/session/service.ts
+++ b/src/session/service.ts
@@ -486,8 +486,8 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    * Returns true if they match
    */
   private verifyEnr(enr: ENR, nodeAddr: INodeAddress): boolean {
-    const enrMultiaddrIP4 = getSocketAddressMultiaddrOnENR(enr, { ...this.ipMode, ip6: false });
-    const enrMultiaddrIP6 = getSocketAddressMultiaddrOnENR(enr, { ...this.ipMode, ip4: false });
+    const enrMultiaddrIP4 = getSocketAddressMultiaddrOnENR(enr, { ...this.ipMode, ip6: false } as IPMode);
+    const enrMultiaddrIP6 = getSocketAddressMultiaddrOnENR(enr, { ...this.ipMode, ip4: false } as IPMode);
     return (
       enr.nodeId === nodeAddr.nodeId &&
       (enrMultiaddrIP4?.equals(nodeAddr.socketAddr) ?? enrMultiaddrIP6?.equals(nodeAddr.socketAddr) ?? true)

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -3,6 +3,8 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import { Multiaddr } from "@multiformats/multiaddr";
 
 import { IPacket } from "../packet/index.js";
+import { BaseENR } from "../enr/enr.js";
+import { SocketAddress } from "../util/ip.js";
 
 export interface ISocketAddr {
   port: number;
@@ -24,11 +26,20 @@ export interface ITransportEvents {
 }
 export type TransportEventEmitter = StrictEventEmitter<EventEmitter, ITransportEvents>;
 
+export type IPMode = {
+  ip4: boolean;
+  ip6: boolean;
+};
+
 export interface ITransportService extends TransportEventEmitter {
-  multiaddr: Multiaddr;
+  bindAddrs: Multiaddr[];
+  ipMode: IPMode;
+
   start(): Promise<void>;
   stop(): Promise<void>;
   send(to: Multiaddr, toId: string, packet: IPacket): Promise<void>;
+
+  getContactableAddr(enr: BaseENR): SocketAddress | undefined;
 
   /** Add 1 expected response of unknown length from IP for rate limiter */
   addExpectedResponse?(ipAddress: string): void;

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -26,10 +26,33 @@ export interface ITransportEvents {
 }
 export type TransportEventEmitter = StrictEventEmitter<EventEmitter, ITransportEvents>;
 
-export type IPMode = {
-  ip4: boolean;
-  ip6: boolean;
-};
+export type IPMode =
+  | {
+      ip4: true;
+      ip6: false;
+    }
+  | {
+      ip4: false;
+      ip6: true;
+    }
+  | {
+      ip4: true;
+      ip6: true;
+    };
+
+export type BindAddrs =
+  | {
+      ip4: Multiaddr;
+      ip6?: undefined;
+    }
+  | {
+      ip4?: undefined;
+      ip6: Multiaddr;
+    }
+  | {
+      ip4: Multiaddr;
+      ip6: Multiaddr;
+    };
 
 export interface ITransportService extends TransportEventEmitter {
   bindAddrs: Multiaddr[];

--- a/src/transport/udp.ts
+++ b/src/transport/udp.ts
@@ -1,10 +1,25 @@
 import * as dgram from "dgram";
 import { EventEmitter } from "events";
-import { Multiaddr, multiaddr } from "@multiformats/multiaddr";
+import { Multiaddr, multiaddr, MultiaddrObject } from "@multiformats/multiaddr";
 
 import { decodePacket, encodePacket, IPacket, MAX_PACKET_SIZE } from "../packet/index.js";
-import { IRemoteInfo, ITransportService, TransportEventEmitter } from "./types.js";
+import { IPMode, IRemoteInfo, ITransportService, TransportEventEmitter } from "./types.js";
 import { IRateLimiter } from "../rateLimit/index.js";
+import { ENR } from "../enr/enr.js";
+import { getSocketAddressOnENR, SocketAddress } from "../util/ip.js";
+
+export type UDPTransportServiceInit = {
+  ip4?: Multiaddr;
+  ip6?: Multiaddr;
+  nodeId: string;
+  rateLimiter?: IRateLimiter;
+};
+
+type SocketOpts = {
+  addr: Multiaddr;
+  opts: MultiaddrObject;
+  socket?: dgram.Socket;
+};
 
 /**
  * This class is responsible for encoding outgoing Packets and decoding incoming Packets over UDP
@@ -13,41 +28,100 @@ export class UDPTransportService
   extends (EventEmitter as { new (): TransportEventEmitter })
   implements ITransportService
 {
-  private socket!: dgram.Socket;
+  readonly bindAddrs: Multiaddr[];
+  readonly ipMode: IPMode;
 
-  public constructor(
-    readonly multiaddr: Multiaddr,
-    private readonly srcId: string,
-    private readonly rateLimiter?: IRateLimiter
-  ) {
+  /**
+   * IPv4 socket and configuration
+   */
+  private readonly ip4?: SocketOpts;
+  /**
+   * IPv6 socket and configuration
+   */
+  private readonly ip6?: SocketOpts;
+  private readonly srcId: string;
+  private readonly rateLimiter?: IRateLimiter;
+
+  public constructor(init: UDPTransportServiceInit) {
     super();
-    const opts = multiaddr.toOptions();
-    if (opts.transport !== "udp") {
-      throw new Error("Local multiaddr must use UDP");
+    this.srcId = init.nodeId;
+    this.rateLimiter = init.rateLimiter;
+    if (!init.ip4 && !init.ip6) {
+      throw new Error("Must bind with an IPv4 and/or IPv6 multiaddr");
+    }
+    const toSocketOpts = (addr: Multiaddr): SocketOpts => {
+      const opts = addr.toOptions();
+      if (opts.transport !== "udp") {
+        throw new Error("Local multiaddr must use UDP");
+      }
+      return {
+        addr,
+        opts,
+      };
+    };
+
+    this.bindAddrs = [];
+    this.ipMode = { ip4: false, ip6: false };
+
+    if (init.ip4) {
+      this.ip4 = toSocketOpts(init.ip4);
+      if (this.ip4.opts.family !== 4) {
+        throw new Error("Configured IPv4 bind address must be IPv4");
+      }
+      this.bindAddrs.push(this.ip4.addr);
+      this.ipMode.ip4 = true;
+    }
+    if (init.ip6) {
+      this.ip6 = toSocketOpts(init.ip6);
+      if (this.ip6.opts.family !== 6) {
+        throw new Error("Configured IPv6 bind address must be IPv6");
+      }
+      this.bindAddrs.push(this.ip6.addr);
+      this.ipMode.ip6 = true;
+    }
+    if (this.ip4 && this.ip6) {
+      if (this.ip4.opts.port === this.ip6.opts.port) {
+        throw new Error("Configured bind multiaddrs must have different ports");
+      }
     }
   }
 
   public async start(): Promise<void> {
-    const opts = this.multiaddr.toOptions();
-    this.socket = dgram.createSocket({
-      recvBufferSize: 16 * MAX_PACKET_SIZE,
-      sendBufferSize: MAX_PACKET_SIZE,
-      type: opts.family === 4 ? "udp4" : "udp6",
-    });
-    this.socket.on("message", this.handleIncoming);
-    return new Promise((resolve) => this.socket.bind(opts.port, opts.host, resolve));
+    const [socket4, socket6] = await Promise.all([
+      this.ip4 ? openSocket(this.ip4.opts) : undefined,
+      this.ip6 ? openSocket(this.ip6.opts) : undefined,
+    ]);
+    if (this.ip4) {
+      socket4?.on("message", this.handleIncoming);
+      this.ip4.socket = socket4;
+    }
+    if (this.ip6) {
+      socket6?.on("message", this.handleIncoming);
+      this.ip6.socket = socket6;
+    }
   }
 
   public async stop(): Promise<void> {
-    this.socket.off("message", this.handleIncoming);
-    return new Promise((resolve) => this.socket.close(resolve));
+    const socket4 = this.ip4?.socket;
+    const socket6 = this.ip6?.socket;
+    socket4?.off("message", this.handleIncoming);
+    socket6?.off("message", this.handleIncoming);
+    await Promise.all([closeSocket(socket4), closeSocket(socket6)]);
   }
 
   public async send(to: Multiaddr, toId: string, packet: IPacket): Promise<void> {
     const nodeAddr = to.toOptions();
-    return new Promise((resolve) =>
-      this.socket.send(encodePacket(toId, packet), nodeAddr.port, nodeAddr.host, () => resolve())
-    );
+    if (nodeAddr.family === 4) {
+      if (!this.ip4) {
+        throw new Error("Cannot send to an IPv4 address without a bound IPv4 socket");
+      }
+      this.ip4.socket?.send(encodePacket(toId, packet), nodeAddr.port, nodeAddr.host);
+    } else if (nodeAddr.family === 6) {
+      if (!this.ip6) {
+        throw new Error("Cannot send to an IPv6 address without a bound IPv6 socket");
+      }
+      this.ip6.socket?.send(encodePacket(toId, packet), nodeAddr.port, nodeAddr.host);
+    }
   }
 
   addExpectedResponse(ipAddress: string): void {
@@ -56,6 +130,10 @@ export class UDPTransportService
 
   removeExpectedResponse(ipAddress: string): void {
     this.rateLimiter?.removeExpectedResponse(ipAddress);
+  }
+
+  getContactableAddr(enr: ENR): SocketAddress | undefined {
+    return getSocketAddressOnENR(enr, this.ipMode);
   }
 
   private handleIncoming = (data: Buffer, rinfo: IRemoteInfo): void => {
@@ -75,4 +153,19 @@ export class UDPTransportService
 
     this.emit("packet", mu, packet);
   };
+}
+
+async function openSocket(opts: MultiaddrObject): Promise<dgram.Socket> {
+  const socket = dgram.createSocket({
+    recvBufferSize: 16 * MAX_PACKET_SIZE,
+    sendBufferSize: MAX_PACKET_SIZE,
+    type: opts.family === 4 ? "udp4" : "udp6",
+  });
+  await new Promise((resolve) => socket.bind(opts.port, opts.host, resolve as () => void));
+  return socket;
+}
+
+async function closeSocket(socket?: dgram.Socket): Promise<void> {
+  if (!socket) return;
+  return new Promise((resolve) => socket.close(resolve));
 }

--- a/src/transport/udp.ts
+++ b/src/transport/udp.ts
@@ -3,14 +3,13 @@ import { EventEmitter } from "events";
 import { Multiaddr, multiaddr, MultiaddrObject } from "@multiformats/multiaddr";
 
 import { decodePacket, encodePacket, IPacket, MAX_PACKET_SIZE } from "../packet/index.js";
-import { IPMode, IRemoteInfo, ITransportService, TransportEventEmitter } from "./types.js";
+import { BindAddrs, IPMode, IRemoteInfo, ITransportService, TransportEventEmitter } from "./types.js";
 import { IRateLimiter } from "../rateLimit/index.js";
 import { ENR } from "../enr/enr.js";
 import { getSocketAddressOnENR, SocketAddress } from "../util/ip.js";
 
 export type UDPTransportServiceInit = {
-  ip4?: Multiaddr;
-  ip6?: Multiaddr;
+  bindAddrs: BindAddrs;
   nodeId: string;
   rateLimiter?: IRateLimiter;
 };
@@ -46,7 +45,7 @@ export class UDPTransportService
     super();
     this.srcId = init.nodeId;
     this.rateLimiter = init.rateLimiter;
-    if (!init.ip4 && !init.ip6) {
+    if (!init.bindAddrs.ip4 && !init.bindAddrs.ip6) {
       throw new Error("Must bind with an IPv4 and/or IPv6 multiaddr");
     }
     const toSocketOpts = (addr: Multiaddr): SocketOpts => {
@@ -61,18 +60,18 @@ export class UDPTransportService
     };
 
     this.bindAddrs = [];
-    this.ipMode = { ip4: false, ip6: false };
+    this.ipMode = { ip4: false, ip6: false } as unknown as IPMode;
 
-    if (init.ip4) {
-      this.ip4 = toSocketOpts(init.ip4);
+    if (init.bindAddrs.ip4) {
+      this.ip4 = toSocketOpts(init.bindAddrs.ip4);
       if (this.ip4.opts.family !== 4) {
         throw new Error("Configured IPv4 bind address must be IPv4");
       }
       this.bindAddrs.push(this.ip4.addr);
       this.ipMode.ip4 = true;
     }
-    if (init.ip6) {
-      this.ip6 = toSocketOpts(init.ip6);
+    if (init.bindAddrs.ip6) {
+      this.ip6 = toSocketOpts(init.bindAddrs.ip6);
       if (this.ip6.opts.family !== 6) {
         throw new Error("Configured IPv6 bind address must be IPv6");
       }

--- a/test/e2e/connect.test.ts
+++ b/test/e2e/connect.test.ts
@@ -30,7 +30,7 @@ describe("discv5 integration test", function () {
     const discv5 = Discv5.create({
       enr,
       peerId,
-      multiaddr: multiAddrUdp,
+      bindAddrs: { ip4: multiAddrUdp },
       config: {
         lookupTimeout: 2000,
       },

--- a/test/e2e/mainnetBootnodes.test.ts
+++ b/test/e2e/mainnetBootnodes.test.ts
@@ -31,7 +31,7 @@ describe("discv5 integration test", function () {
       const discv5 = Discv5.create({
         enr,
         peerId,
-        multiaddr: multiAddrUdp,
+        bindAddrs: { ip4: multiAddrUdp },
         config: {
           lookupTimeout: 2000,
         },

--- a/test/e2e/mainnetBootnodes.test.ts
+++ b/test/e2e/mainnetBootnodes.test.ts
@@ -25,6 +25,9 @@ describe("discv5 integration test", function () {
       ip6: multiaddr(`/ip6/::/udp/${port++}`),
     },
   ]) {
+    // ip6 test fails in github runner
+    if (process.env.CI && bindAddrs.ip6) return;
+
     it(`Connect to nodes from Mainnet bootnodes: ${Object.keys(bindAddrs)}`, async () => {
       const peerId = RANDOM_PEER_ID
         ? await createSecp256k1PeerId()

--- a/test/e2e/mainnetBootnodes.test.ts
+++ b/test/e2e/mainnetBootnodes.test.ts
@@ -25,10 +25,10 @@ describe("discv5 integration test", function () {
       ip6: multiaddr(`/ip6/::/udp/${port++}`),
     },
   ]) {
-    // ip6 test fails in github runner
-    if (process.env.CI && bindAddrs.ip6) return;
+    it(`Connect to nodes from Mainnet bootnodes: ${Object.keys(bindAddrs)}`, async function () {
+      // ip6 test fails in github runner
+      if (process.env.CI && bindAddrs.ip6) this.skip();
 
-    it(`Connect to nodes from Mainnet bootnodes: ${Object.keys(bindAddrs)}`, async () => {
       const peerId = RANDOM_PEER_ID
         ? await createSecp256k1PeerId()
         : await createFromPrivKey(

--- a/test/unit/service/service.test.ts
+++ b/test/unit/service/service.test.ts
@@ -12,7 +12,7 @@ describe("Discv5", async () => {
   const enr0 = SignableENR.createV4(kp0);
   const mu0 = multiaddr("/ip4/127.0.0.1/udp/40000");
 
-  const service0 = Discv5.create({ enr: enr0, peerId: peerId0, multiaddr: mu0 });
+  const service0 = Discv5.create({ enr: enr0, peerId: peerId0, bindAddrs: { ip4: mu0 } });
 
   beforeEach(async () => {
     await service0.start();
@@ -27,7 +27,7 @@ describe("Discv5", async () => {
   });
 
   it("should allow to pick a port and network interface as a multiaddr", async () => {
-    expect(service0.bindAddress.toString()).eq(mu0.toString());
+    expect(service0.bindAddrs[0].toString()).eq(mu0.toString());
   });
 
   it("should add new enrs", async () => {
@@ -53,7 +53,7 @@ describe("Discv5", async () => {
     enr1.set("ip", addr1[0][1]);
     enr1.set("udp", addr1[1][1]);
     enr1.encode();
-    const service1 = Discv5.create({ enr: enr1, peerId: peerId1, multiaddr: mu1 });
+    const service1 = Discv5.create({ enr: enr1, peerId: peerId1, bindAddrs: { ip4: mu1 } });
     await service1.start();
     for (let i = 0; i < 100; i++) {
       const kp = generateKeypair(KeypairType.Secp256k1);

--- a/test/unit/session/service.test.ts
+++ b/test/unit/session/service.test.ts
@@ -39,8 +39,8 @@ describe("session service", () => {
   let service1: SessionService;
 
   beforeEach(async () => {
-    transport0 = new UDPTransportService(addr0, enr0.nodeId);
-    transport1 = new UDPTransportService(addr1, enr1.nodeId);
+    transport0 = new UDPTransportService({ ip4: addr0, nodeId: enr0.nodeId });
+    transport1 = new UDPTransportService({ ip4: addr1, nodeId: enr1.nodeId });
 
     service0 = new SessionService(defaultConfig, enr0, kp0, transport0);
     service1 = new SessionService(defaultConfig, enr1, kp1, transport1);

--- a/test/unit/session/service.test.ts
+++ b/test/unit/session/service.test.ts
@@ -39,8 +39,8 @@ describe("session service", () => {
   let service1: SessionService;
 
   beforeEach(async () => {
-    transport0 = new UDPTransportService({ ip4: addr0, nodeId: enr0.nodeId });
-    transport1 = new UDPTransportService({ ip4: addr1, nodeId: enr1.nodeId });
+    transport0 = new UDPTransportService({ bindAddrs: { ip4: addr0 }, nodeId: enr0.nodeId });
+    transport1 = new UDPTransportService({ bindAddrs: { ip4: addr1 }, nodeId: enr1.nodeId });
 
     service0 = new SessionService(defaultConfig, enr0, kp0, transport0);
     service1 = new SessionService(defaultConfig, enr1, kp1, transport1);

--- a/test/unit/transport/udp.test.ts
+++ b/test/unit/transport/udp.test.ts
@@ -11,12 +11,12 @@ describe("UDP transport", () => {
   const nodeIdA = toHex(Buffer.alloc(32, 1));
   const portA = 49523;
   const multiaddrA = multiaddr(`/ip4/${address}/udp/${portA}`);
-  const a = new UDPTransportService(multiaddrA, nodeIdA);
+  const a = new UDPTransportService({ ip4: multiaddrA, nodeId: nodeIdA });
 
   const nodeIdB = toHex(Buffer.alloc(32, 2));
   const portB = portA + 1;
   const multiaddrB = multiaddr(`/ip4/${address}/udp/${portB}`);
-  const b = new UDPTransportService(multiaddrB, nodeIdB);
+  const b = new UDPTransportService({ ip4: multiaddrB, nodeId: nodeIdB });
 
   before(async () => {
     await a.start();

--- a/test/unit/transport/udp.test.ts
+++ b/test/unit/transport/udp.test.ts
@@ -6,7 +6,7 @@ import { PacketType, IPacket, NONCE_SIZE, MASKING_IV_SIZE } from "../../../src/p
 import { UDPTransportService } from "../../../src/transport/index.js";
 import { toHex } from "../../../src/util/index.js";
 
-describe("UDP transport", () => {
+describe("UDP4 transport", () => {
   const address = "127.0.0.1";
   const nodeIdA = toHex(Buffer.alloc(32, 1));
   const portA = 49523;
@@ -50,5 +50,114 @@ describe("UDP transport", () => {
     expect(rPacket.maskingIv).to.deep.equal(messagePacket.maskingIv);
     expect(rPacket.header).to.deep.equal(messagePacket.header);
     expect(rPacket.message).to.deep.equal(messagePacket.message);
+  });
+});
+
+describe("UDP6 transport", () => {
+  const address = "::1";
+  const nodeIdA = toHex(Buffer.alloc(32, 1));
+  const portA = 49523;
+  const multiaddrA = multiaddr(`/ip6/${address}/udp/${portA}`);
+  const a = new UDPTransportService({ bindAddrs: { ip6: multiaddrA }, nodeId: nodeIdA });
+
+  const nodeIdB = toHex(Buffer.alloc(32, 2));
+  const portB = portA + 1;
+  const multiaddrB = multiaddr(`/ip6/${address}/udp/${portB}`);
+  const b = new UDPTransportService({ bindAddrs: { ip6: multiaddrB }, nodeId: nodeIdB });
+
+  before(async () => {
+    await a.start();
+    await b.start();
+  });
+
+  after(async () => {
+    await a.stop();
+    await b.stop();
+  });
+
+  it("should send and receive messages", async () => {
+    const messagePacket: IPacket = {
+      maskingIv: Buffer.alloc(MASKING_IV_SIZE),
+      header: {
+        protocolId: "discv5",
+        version: 1,
+        flag: PacketType.Message,
+        nonce: Buffer.alloc(NONCE_SIZE),
+        authdataSize: 32,
+        authdata: Buffer.alloc(32, 2),
+      },
+      message: Buffer.alloc(44, 1),
+    };
+    const received = new Promise<[Multiaddr, IPacket]>((resolve) =>
+      a.once("packet", (sender, packet) => resolve([sender, packet]))
+    );
+    await b.send(multiaddrA, nodeIdA, messagePacket);
+    const [rSender, rPacket] = await received;
+    expect(rSender.toString()).to.deep.equal(multiaddrB.toString());
+    expect(rPacket.maskingIv).to.deep.equal(messagePacket.maskingIv);
+    expect(rPacket.header).to.deep.equal(messagePacket.header);
+    expect(rPacket.message).to.deep.equal(messagePacket.message);
+  });
+});
+
+describe("UDP4+6 transport", () => {
+  const address4 = "127.0.0.1";
+  const address6 = "::1";
+  const nodeIdA = toHex(Buffer.alloc(32, 1));
+  const portA = 49523;
+  const multiaddr4A = multiaddr(`/ip4/${address4}/udp/${portA}`);
+  const multiaddr6A = multiaddr(`/ip6/${address6}/udp/${portA + 1}`);
+  const a = new UDPTransportService({ bindAddrs: { ip4: multiaddr4A, ip6: multiaddr6A }, nodeId: nodeIdA });
+
+  const nodeIdB = toHex(Buffer.alloc(32, 2));
+  const portB = portA + 1;
+  const multiaddr4B = multiaddr(`/ip4/${address4}/udp/${portB}`);
+  const multiaddr6B = multiaddr(`/ip6/${address6}/udp/${portB + 1}`);
+  const b = new UDPTransportService({ bindAddrs: { ip4: multiaddr4B, ip6: multiaddr6B }, nodeId: nodeIdB });
+
+  before(async () => {
+    await a.start();
+    await b.start();
+  });
+
+  after(async () => {
+    await a.stop();
+    await b.stop();
+  });
+
+  it("should send and receive messages", async () => {
+    const messagePacket: IPacket = {
+      maskingIv: Buffer.alloc(MASKING_IV_SIZE),
+      header: {
+        protocolId: "discv5",
+        version: 1,
+        flag: PacketType.Message,
+        nonce: Buffer.alloc(NONCE_SIZE),
+        authdataSize: 32,
+        authdata: Buffer.alloc(32, 2),
+      },
+      message: Buffer.alloc(44, 1),
+    };
+    async function send(multiaddr: Multiaddr, nodeId: string, packet: IPacket): Promise<[Multiaddr, IPacket]> {
+      const received = new Promise<[Multiaddr, IPacket]>((resolve) =>
+        a.once("packet", (sender, packet) => resolve([sender, packet]))
+      );
+      await b.send(multiaddr, nodeId, packet);
+      return await received;
+    }
+    {
+      const [rSender, rPacket] = await send(multiaddr6A, nodeIdA, messagePacket);
+      expect(rSender.toString()).to.deep.equal(multiaddr6B.toString());
+      expect(rPacket.maskingIv).to.deep.equal(messagePacket.maskingIv);
+      expect(rPacket.header).to.deep.equal(messagePacket.header);
+      expect(rPacket.message).to.deep.equal(messagePacket.message);
+    }
+    {
+      const [rSender, rPacket] = await send(multiaddr4A, nodeIdA, messagePacket);
+      expect(rSender.toString()).to.deep.equal(multiaddr4B.toString());
+      expect(rPacket.maskingIv).to.deep.equal(messagePacket.maskingIv);
+      expect(rPacket.header).to.deep.equal(messagePacket.header);
+      expect(rPacket.message).to.deep.equal(messagePacket.message);
+    }
   });
 });

--- a/test/unit/transport/udp.test.ts
+++ b/test/unit/transport/udp.test.ts
@@ -11,12 +11,12 @@ describe("UDP transport", () => {
   const nodeIdA = toHex(Buffer.alloc(32, 1));
   const portA = 49523;
   const multiaddrA = multiaddr(`/ip4/${address}/udp/${portA}`);
-  const a = new UDPTransportService({ ip4: multiaddrA, nodeId: nodeIdA });
+  const a = new UDPTransportService({ bindAddrs: { ip4: multiaddrA }, nodeId: nodeIdA });
 
   const nodeIdB = toHex(Buffer.alloc(32, 2));
   const portB = portA + 1;
   const multiaddrB = multiaddr(`/ip4/${address}/udp/${portB}`);
-  const b = new UDPTransportService({ ip4: multiaddrB, nodeId: nodeIdB });
+  const b = new UDPTransportService({ bindAddrs: { ip4: multiaddrB }, nodeId: nodeIdB });
 
   before(async () => {
     await a.start();

--- a/test/unit/util/ip.test.ts
+++ b/test/unit/util/ip.test.ts
@@ -134,10 +134,10 @@ describe("get/set SocketAddress on ENR", () => {
       port: 53,
     };
     const enr = SignableENR.createV4(generateKeypair(KeypairType.Secp256k1));
-    expect(getSocketAddressOnENR(enr)).to.equal(undefined);
+    expect(getSocketAddressOnENR(enr, { ip4: true, ip6: false })).to.equal(undefined);
 
     setSocketAddressOnENR(enr, addr);
-    expect(getSocketAddressOnENR(enr)).to.deep.equal(addr);
+    expect(getSocketAddressOnENR(enr, { ip4: true, ip6: false })).to.deep.equal(addr);
   });
 });
 


### PR DESCRIPTION
Resolves #167

- Adds the capability to specify either an ip4, ip6, or both bind addresses instead of just a single bind address
- By specifying the addresses to bind to, this sets the `IPMode` (either ip4, ip6, or both).
- Based on the specified `IPMode`, several things happen:
  - a udp4 socket and/or a udp6 socket are opened
  - discovered peers will be contacted based on the proper entry in their enr (either ip+udp or ip6+udp6) (ip6 is the default in the case of the 'both' IPMode) using the proper socket