### PR TITLE
fix: update service.ts to make sure callback is called in sendPing when initiated by the user

### DIFF
--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -922,6 +922,10 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
           request: createFindNodeMessage([0]),
         });
       }
+      // If sendPing was initiated by the user and callback function set, call it and resolve the promise
+      if (activeRequest.callback) {
+          activeRequest.callback(null, message)
+      }
       this.connectionUpdated(nodeAddr.nodeId, { type: ConnectionStatusType.PongReceived, enr });
     }
   }


### PR DESCRIPTION
fix: If the user calls the function sendPing the promise is never resolved as the call back in case of success is never called.  Currently the callback is only called on case of failure (function rpcFailure) leading to a promise rejection. Adding the code in handlePong should resolve this.

F.e. if the user calls sendPing:
const pong = await this.discv5.sendPing(enr)
never resolve if ping successfully and pong message received