### PR TITLE
feat!: add pluggable enr crypto interface

### DIFF
--- a/bench/enr/index.bench.ts
+++ b/bench/enr/index.bench.ts
@@ -1,12 +1,12 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {generateKeypair, KeypairType} from "../../src/keypair";
-import {ENR} from "../../src/enr";
+import {generateKeypair} from "../../src/keypair";
+import {SignableENR} from "../../src/enr";
 
 describe("ENR", function() {
   setBenchOpts({runs: 50000});
 
-  const keypairWithPrivateKey = generateKeypair(KeypairType.secp256k1);
-  const enr = ENR.createV4(keypairWithPrivateKey.privateKey);
+  const keypairWithPrivateKey = generateKeypair("secp256k1");
+  const enr = SignableENR.createV4(keypairWithPrivateKey);
   enr.ip = "127.0.0.1";
   enr.tcp = 8080;
 

--- a/bench/keypair/index.bench.ts
+++ b/bench/keypair/index.bench.ts
@@ -1,17 +1,16 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {createPeerIdFromKeypair, generateKeypair} from "../../src/keypair";
+import {generateKeypair} from "../../src/keypair/index.js";
+import { createPeerIdFromPrivateKey, createPeerIdFromPublicKey } from "../../src/enr/index.js";
 
-describe("createPeerIdFromKeypair", function() {
+describe("createPeerIdFromPrivateKey", function() {
   setBenchOpts({runs: 4000});
 
-  const keypairWithPrivateKey = generateKeypair("secp256k1");
-  const keypairWithoutPrivateKey = generateKeypair("secp256k1");
-  delete (keypairWithoutPrivateKey as any)._privateKey;
+  const keypair = generateKeypair("secp256k1");
 
-  itBench("createPeerIdFromKeypair - private key", () => {
-    return createPeerIdFromKeypair(keypairWithPrivateKey);
+  itBench("createPeerIdFromPrivateKey", () => {
+    return createPeerIdFromPrivateKey(keypair.type, keypair.privateKey);
   });
-  itBench("createPeerIdFromKeypair - no private key", () => {
-    return createPeerIdFromKeypair(keypairWithoutPrivateKey);
+  itBench("createPeerIdFromPublicKey", () => {
+    return createPeerIdFromPublicKey(keypair.type, keypair.publicKey);
   });
 });

--- a/bench/keypair/index.bench.ts
+++ b/bench/keypair/index.bench.ts
@@ -1,11 +1,11 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {createPeerIdFromKeypair, generateKeypair, KeypairType} from "../../src/keypair";
+import {createPeerIdFromKeypair, generateKeypair} from "../../src/keypair";
 
 describe("createPeerIdFromKeypair", function() {
   setBenchOpts({runs: 4000});
 
-  const keypairWithPrivateKey = generateKeypair(KeypairType.secp256k1);
-  const keypairWithoutPrivateKey = generateKeypair(KeypairType.secp256k1);
+  const keypairWithPrivateKey = generateKeypair("secp256k1");
+  const keypairWithoutPrivateKey = generateKeypair("secp256k1");
   delete (keypairWithoutPrivateKey as any)._privateKey;
 
   itBench("createPeerIdFromKeypair - private key", () => {

--- a/src/enr/index.ts
+++ b/src/enr/index.ts
@@ -1,6 +1,5 @@
-import * as v4Crypto from "./v4.js";
-export const v4 = v4Crypto;
 export * from "./constants.js";
 export * from "./enr.js";
 export * from "./types.js";
 export * from "./create.js";
+export * from "./peerId.js";

--- a/src/enr/peerId.ts
+++ b/src/enr/peerId.ts
@@ -1,0 +1,52 @@
+import { PeerId } from "@libp2p/interface/peer-id";
+import { peerIdFromKeys } from "@libp2p/peer-id";
+import { keysPBM, supportedKeys } from "@libp2p/crypto/keys";
+import { KeyType } from "@libp2p/interface/keys";
+import { ERR_TYPE_NOT_IMPLEMENTED } from "../keypair/constants.js";
+
+/** Translate to KeyType from keysPBM enum */
+enum KeyTypeTranslator {
+  RSA = "RSA",
+  Ed25519 = "Ed25519",
+  Secp256k1 = "secp256k1",
+}
+
+export async function createPeerIdFromPublicKey(type: KeyType, publicKey: Uint8Array): Promise<PeerId> {
+  switch (type) {
+    case "secp256k1": {
+      const pubKey = new supportedKeys.secp256k1.Secp256k1PublicKey(publicKey);
+      return peerIdFromKeys(pubKey.bytes);
+    }
+    default:
+      throw new Error(ERR_TYPE_NOT_IMPLEMENTED);
+  }
+}
+
+export async function createPeerIdFromPrivateKey(type: KeyType, privateKey: Uint8Array): Promise<PeerId> {
+  switch (type) {
+    case "secp256k1": {
+      const privKey = new supportedKeys.secp256k1.Secp256k1PrivateKey(privateKey);
+      return peerIdFromKeys(privKey.public.bytes, privKey.bytes);
+    }
+    default:
+      throw new Error(ERR_TYPE_NOT_IMPLEMENTED);
+  }
+}
+
+export function createPublicKeyFromPeerId(peerId: PeerId): { type: KeyType; publicKey: Uint8Array } {
+  // pub/privkey bytes from peer-id are encoded in protobuf format
+  if (!peerId.publicKey) {
+    throw new Error("Public key required");
+  }
+  const pub = keysPBM.PublicKey.decode(peerId.publicKey);
+  return { type: KeyTypeTranslator[pub.Type!], publicKey: pub.Data! };
+}
+
+export function createPrivateKeyFromPeerId(peerId: PeerId): { type: KeyType; privateKey: Uint8Array } {
+  // pub/privkey bytes from peer-id are encoded in protobuf format
+  if (!peerId.privateKey) {
+    throw new Error("Private key required");
+  }
+  const priv = keysPBM.PrivateKey.decode(peerId.privateKey);
+  return { type: KeyTypeTranslator[priv.Type!], privateKey: priv.Data! };
+}

--- a/src/enr/util.ts
+++ b/src/enr/util.ts
@@ -1,0 +1,5 @@
+// multiaddr 8.0.0 expects an Uint8Array with internal buffer starting at 0 offset
+export function toNewUint8Array(buf: Uint8Array): Uint8Array {
+  const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  return new Uint8Array(arrayBuffer);
+}

--- a/src/enr/v4.ts
+++ b/src/enr/v4.ts
@@ -8,10 +8,6 @@ export function hash(input: Buffer): Buffer {
   return keccak.digest(input);
 }
 
-export function createPrivateKey(): Buffer {
-  return secp256k1.privateKeyGenerate();
-}
-
 export function publicKey(privKey: Buffer): Buffer {
   return secp256k1.publicKeyCreate(privKey);
 }
@@ -26,29 +22,4 @@ export function verify(pubKey: Buffer, msg: Buffer, sig: Buffer): boolean {
 
 export function nodeId(pubKey: Buffer): NodeId {
   return createNodeId(hash(secp256k1.publicKeyConvert(pubKey, false).slice(1)));
-}
-
-export class ENRKeyPair {
-  public readonly nodeId: NodeId;
-  public readonly privateKey: Buffer;
-  public readonly publicKey: Buffer;
-
-  public constructor(privateKey?: Buffer) {
-    if (privateKey) {
-      if (!secp256k1.privateKeyVerify(privateKey)) {
-        throw new Error("Invalid private key");
-      }
-    }
-    this.privateKey = privateKey || createPrivateKey();
-    this.publicKey = publicKey(this.privateKey);
-    this.nodeId = nodeId(this.publicKey);
-  }
-
-  public sign(msg: Buffer): Buffer {
-    return sign(this.privateKey, msg);
-  }
-
-  public verify(msg: Buffer, sig: Buffer): boolean {
-    return verify(this.publicKey, msg, sig);
-  }
 }

--- a/src/keypair/index.ts
+++ b/src/keypair/index.ts
@@ -1,8 +1,9 @@
 import { PeerId } from "@libp2p/interface/peer-id";
 import { peerIdFromKeys } from "@libp2p/peer-id";
 import { keysPBM, supportedKeys } from "@libp2p/crypto/keys";
+import { KeyType } from "@libp2p/interface/keys";
 
-import { IKeypair, KeypairType } from "./types.js";
+import { IKeypair } from "./types.js";
 import { ERR_TYPE_NOT_IMPLEMENTED } from "./constants.js";
 import { Secp256k1Keypair } from "./secp256k1.js";
 import { toBuffer } from "../util/index.js";
@@ -10,18 +11,18 @@ import { toBuffer } from "../util/index.js";
 export * from "./types.js";
 export * from "./secp256k1.js";
 
-export function generateKeypair(type: KeypairType): IKeypair {
+export function generateKeypair(type: KeyType): IKeypair {
   switch (type) {
-    case KeypairType.Secp256k1:
+    case "secp256k1":
       return Secp256k1Keypair.generate();
     default:
       throw new Error(ERR_TYPE_NOT_IMPLEMENTED);
   }
 }
 
-export function createKeypair(type: KeypairType, privateKey?: Buffer, publicKey?: Buffer): IKeypair {
+export function createKeypair(type: KeyType, privateKey?: Buffer, publicKey?: Buffer): IKeypair {
   switch (type) {
-    case KeypairType.Secp256k1:
+    case "secp256k1":
       return new Secp256k1Keypair(privateKey, publicKey);
     default:
       throw new Error(ERR_TYPE_NOT_IMPLEMENTED);
@@ -30,7 +31,7 @@ export function createKeypair(type: KeypairType, privateKey?: Buffer, publicKey?
 
 export async function createPeerIdFromKeypair(keypair: IKeypair): Promise<PeerId> {
   switch (keypair.type) {
-    case KeypairType.Secp256k1: {
+    case "secp256k1": {
       if (keypair.hasPrivateKey()) {
         const privKey = new supportedKeys.secp256k1.Secp256k1PrivateKey(keypair.privateKey, keypair.publicKey);
         const pubKey = privKey.public;
@@ -45,6 +46,13 @@ export async function createPeerIdFromKeypair(keypair: IKeypair): Promise<PeerId
   }
 }
 
+/** Translate to KeyType from keysPBM enum */
+enum KeyTypeTranslator {
+  RSA = "RSA",
+  Ed25519 = "Ed25519",
+  Secp256k1 = "secp256k1",
+}
+
 export function createKeypairFromPeerId(peerId: PeerId): IKeypair {
   // pub/privkey bytes from peer-id are encoded in protobuf format
   if (!peerId.publicKey) {
@@ -53,8 +61,8 @@ export function createKeypairFromPeerId(peerId: PeerId): IKeypair {
   const pub = keysPBM.PublicKey.decode(peerId.publicKey);
   if (peerId.privateKey) {
     const priv = keysPBM.PrivateKey.decode(peerId.privateKey);
-    return createKeypair(KeypairType[pub.Type!] as KeypairType, toBuffer(priv.Data!), toBuffer(pub.Data!));
+    return createKeypair(KeyTypeTranslator[pub.Type!], toBuffer(priv.Data!), toBuffer(pub.Data!));
   } else {
-    return createKeypair(KeypairType[pub.Type!] as KeypairType, undefined, toBuffer(pub.Data!));
+    return createKeypair(KeyTypeTranslator[pub.Type!], undefined, toBuffer(pub.Data!));
   }
 }

--- a/src/keypair/index.ts
+++ b/src/keypair/index.ts
@@ -1,6 +1,3 @@
-import { PeerId } from "@libp2p/interface/peer-id";
-import { peerIdFromKeys } from "@libp2p/peer-id";
-import { keysPBM, supportedKeys } from "@libp2p/crypto/keys";
 import { KeyType } from "@libp2p/interface/keys";
 
 import { IKeypair } from "./types.js";
@@ -20,49 +17,26 @@ export function generateKeypair(type: KeyType): IKeypair {
   }
 }
 
-export function createKeypair(type: KeyType, privateKey?: Buffer, publicKey?: Buffer): IKeypair {
-  switch (type) {
-    case "secp256k1":
-      return new Secp256k1Keypair(privateKey, publicKey);
-    default:
-      throw new Error(ERR_TYPE_NOT_IMPLEMENTED);
-  }
-}
-
-export async function createPeerIdFromKeypair(keypair: IKeypair): Promise<PeerId> {
-  switch (keypair.type) {
-    case "secp256k1": {
-      if (keypair.hasPrivateKey()) {
-        const privKey = new supportedKeys.secp256k1.Secp256k1PrivateKey(keypair.privateKey, keypair.publicKey);
-        const pubKey = privKey.public;
-        return peerIdFromKeys(pubKey.bytes, privKey.bytes);
-      } else {
-        const pubKey = new supportedKeys.secp256k1.Secp256k1PublicKey(keypair.publicKey);
-        return peerIdFromKeys(pubKey.bytes);
-      }
+type KeypairInit =
+  | {
+      type: KeyType;
+      privateKey: Uint8Array;
+      publicKey?: Uint8Array;
     }
+  | {
+      type: KeyType;
+      privateKey?: Uint8Array;
+      publicKey: Uint8Array;
+    };
+
+export function createKeypair(init: KeypairInit): IKeypair {
+  switch (init.type) {
+    case "secp256k1":
+      return new Secp256k1Keypair(
+        init.privateKey ? toBuffer(init.privateKey) : undefined,
+        init.publicKey ? toBuffer(init.publicKey) : undefined
+      );
     default:
       throw new Error(ERR_TYPE_NOT_IMPLEMENTED);
-  }
-}
-
-/** Translate to KeyType from keysPBM enum */
-enum KeyTypeTranslator {
-  RSA = "RSA",
-  Ed25519 = "Ed25519",
-  Secp256k1 = "secp256k1",
-}
-
-export function createKeypairFromPeerId(peerId: PeerId): IKeypair {
-  // pub/privkey bytes from peer-id are encoded in protobuf format
-  if (!peerId.publicKey) {
-    throw new Error("Public key required");
-  }
-  const pub = keysPBM.PublicKey.decode(peerId.publicKey);
-  if (peerId.privateKey) {
-    const priv = keysPBM.PrivateKey.decode(peerId.privateKey);
-    return createKeypair(KeyTypeTranslator[pub.Type!], toBuffer(priv.Data!), toBuffer(pub.Data!));
-  } else {
-    return createKeypair(KeyTypeTranslator[pub.Type!], undefined, toBuffer(pub.Data!));
   }
 }

--- a/src/keypair/secp256k1.ts
+++ b/src/keypair/secp256k1.ts
@@ -25,7 +25,7 @@ export const Secp256k1Keypair: IKeypairClass = class Secp256k1Keypair extends Ab
   readonly type: KeyType;
 
   constructor(privateKey?: Buffer, publicKey?: Buffer) {
-    let pub = publicKey;
+    let pub = publicKey ?? secp256k1.publicKeyCreate(privateKey!);
     if (pub) {
       pub = secp256k1PublicKeyToCompressed(pub);
     }

--- a/src/keypair/secp256k1.ts
+++ b/src/keypair/secp256k1.ts
@@ -1,5 +1,6 @@
 import secp256k1 from "bcrypto/lib/secp256k1.js";
-import { AbstractKeypair, IKeypair, IKeypairClass, KeypairType } from "./types.js";
+import { KeyType } from "@libp2p/interface/keys";
+import { AbstractKeypair, IKeypair, IKeypairClass } from "./types.js";
 import { ERR_INVALID_KEYPAIR_TYPE } from "./constants.js";
 
 export function secp256k1PublicKeyToCompressed(publicKey: Buffer): Buffer {
@@ -21,7 +22,7 @@ export function secp256k1PublicKeyToRaw(publicKey: Buffer): Buffer {
 }
 
 export const Secp256k1Keypair: IKeypairClass = class Secp256k1Keypair extends AbstractKeypair implements IKeypair {
-  readonly type: KeypairType;
+  readonly type: KeyType;
 
   constructor(privateKey?: Buffer, publicKey?: Buffer) {
     let pub = publicKey;
@@ -29,7 +30,7 @@ export const Secp256k1Keypair: IKeypairClass = class Secp256k1Keypair extends Ab
       pub = secp256k1PublicKeyToCompressed(pub);
     }
     super(privateKey, pub);
-    this.type = KeypairType.Secp256k1;
+    this.type = "secp256k1";
   }
 
   static generate(): Secp256k1Keypair {

--- a/src/keypair/types.ts
+++ b/src/keypair/types.ts
@@ -1,11 +1,7 @@
-export enum KeypairType {
-  RSA = 0,
-  Ed25519 = 1,
-  Secp256k1 = 2,
-}
+import { KeyType } from "@libp2p/interface/keys";
 
 export interface IKeypair {
-  type: KeypairType;
+  type: KeyType;
   privateKey: Buffer;
   publicKey: Buffer;
   privateKeyVerify(): boolean;

--- a/src/session/crypto.ts
+++ b/src/session/crypto.ts
@@ -57,7 +57,7 @@ export function deriveKeysFromPubkey(
   ephemPK: Buffer,
   challengeData: Buffer
 ): [Buffer, Buffer] {
-  const secret = kpriv.deriveSecret(createKeypair(kpriv.type, undefined, ephemPK));
+  const secret = kpriv.deriveSecret(createKeypair({ type: kpriv.type, publicKey: ephemPK }));
   return deriveKey(secret, remoteId, localId, challengeData);
 }
 

--- a/src/session/crypto.ts
+++ b/src/session/crypto.ts
@@ -33,7 +33,7 @@ export function generateSessionKeys(
   const secret = ephemKeypair.deriveSecret(remoteKeypair);
   /* TODO possibly not needed, check tests
   const ephemPubkey =
-    remoteKeypair.type === KeypairType.secp256k1
+    remoteKeypair.type === "secp256k1"
       ? secp256k1PublicKeyToCompressed(ephemKeypair.publicKey)
       : ephemKeypair.publicKey;
   */

--- a/src/session/session.ts
+++ b/src/session/session.ts
@@ -17,7 +17,7 @@ import {
   idSign,
   idVerify,
 } from "./crypto.js";
-import { IKeypair } from "../keypair/index.js";
+import { IKeypair, createKeypair } from "../keypair/index.js";
 import { randomBytes } from "crypto";
 import { RequestId } from "../message/index.js";
 import { IChallenge } from ".";
@@ -101,7 +101,15 @@ export class Session {
     }
 
     // verify the auth header nonce
-    if (!idVerify(enr.keypair, challenge.data, ephPubkey, localId, idSignature)) {
+    if (
+      !idVerify(
+        createKeypair({ type: enr.keypairType, publicKey: enr.publicKey }),
+        challenge.data,
+        ephPubkey,
+        localId,
+        idSignature
+      )
+    ) {
       throw new Error(ERR_INVALID_SIG);
     }
 

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -3,7 +3,7 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import { Multiaddr } from "@multiformats/multiaddr";
 
 import { IPacket } from "../packet/index.js";
-import { BaseENR } from "../enr/enr.js";
+import { BaseENR } from "../enr/index.js";
 import { SocketAddress } from "../util/ip.js";
 
 export interface ISocketAddr {

--- a/src/transport/udp.ts
+++ b/src/transport/udp.ts
@@ -5,7 +5,7 @@ import { Multiaddr, multiaddr, MultiaddrObject } from "@multiformats/multiaddr";
 import { decodePacket, encodePacket, IPacket, MAX_PACKET_SIZE } from "../packet/index.js";
 import { BindAddrs, IPMode, IRemoteInfo, ITransportService, TransportEventEmitter } from "./types.js";
 import { IRateLimiter } from "../rateLimit/index.js";
-import { ENR } from "../enr/enr.js";
+import { ENR } from "../enr/index.js";
 import { getSocketAddressOnENR, SocketAddress } from "../util/ip.js";
 
 export type UDPTransportServiceInit = {

--- a/src/util/toBuffer.ts
+++ b/src/util/toBuffer.ts
@@ -1,11 +1,6 @@
 export function toBuffer(arr: Uint8Array): Buffer {
+  if (arr instanceof Buffer) return arr;
   return Buffer.from(arr.buffer, arr.byteOffset, arr.length);
-}
-
-// multiaddr 8.0.0 expects an Uint8Array with internal buffer starting at 0 offset
-export function toNewUint8Array(buf: Uint8Array): Uint8Array {
-  const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
-  return new Uint8Array(arrayBuffer);
 }
 
 export function numberToBuffer(value: number, length: number): Buffer {

--- a/test/unit/enr/enr.test.ts
+++ b/test/unit/enr/enr.test.ts
@@ -3,13 +3,13 @@ import { expect } from "chai";
 import { multiaddr } from "@multiformats/multiaddr";
 import { createSecp256k1PeerId } from "@libp2p/peer-id-factory";
 import { BaseENR, ENR, SignableENR, v4 } from "../../../src/enr/index.js";
-import { createKeypair, KeypairType, toHex } from "../../../src/index.js";
+import { createKeypair, toHex } from "../../../src/index.js";
 
 describe("ENR spec test vector", () => {
   // spec enr https://eips.ethereum.org/EIPS/eip-778
   const privateKey = Buffer.from("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291", "hex");
   const publicKey = v4.publicKey(privateKey);
-  const keypair = createKeypair(KeypairType.Secp256k1, privateKey, publicKey);
+  const keypair = createKeypair("secp256k1", privateKey, publicKey);
   const text =
     "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
   const seq = BigInt(1);
@@ -67,7 +67,7 @@ describe("ENR spec test vector", () => {
 describe("ENR multiaddr support", () => {
   const privateKey = Buffer.from("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291", "hex");
   const publicKey = v4.publicKey(privateKey);
-  const keypair = createKeypair(KeypairType.Secp256k1, privateKey, publicKey);
+  const keypair = createKeypair("secp256k1", privateKey, publicKey);
   let record: SignableENR;
 
   beforeEach(() => {

--- a/test/unit/kademlia/kademlia.test.ts
+++ b/test/unit/kademlia/kademlia.test.ts
@@ -5,7 +5,7 @@ import { ENR, createNodeId, SignableENR } from "../../../src/enr/index.js";
 import { EntryStatus, log2Distance } from "../../../src/kademlia/index.js";
 import { randomBytes } from "@libp2p/crypto";
 import { toBuffer } from "../../../src/util/index.js";
-import { generateKeypair, KeypairType } from "../../../src/index.js";
+import { generateKeypair } from "../../../src/index.js";
 
 describe("Kademlia routing table", () => {
   const nodeId = createNodeId(Buffer.alloc(32));
@@ -119,7 +119,7 @@ describe("Kademlia routing table", () => {
 });
 
 function randomENR(): ENR {
-  const keypair = generateKeypair(KeypairType.Secp256k1);
+  const keypair = generateKeypair("secp256k1");
   return SignableENR.createV4(keypair).toENR();
 }
 

--- a/test/unit/kademlia/kademlia.test.ts
+++ b/test/unit/kademlia/kademlia.test.ts
@@ -120,7 +120,7 @@ describe("Kademlia routing table", () => {
 
 function randomENR(): ENR {
   const keypair = generateKeypair("secp256k1");
-  return SignableENR.createV4(keypair).toENR();
+  return SignableENR.createV4(keypair.privateKey).toENR();
 }
 
 function randomNodeId(): string {

--- a/test/unit/keypair/index.test.ts
+++ b/test/unit/keypair/index.test.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
 import { createFromPrivKey, createFromPubKey } from "@libp2p/peer-id-factory";
 import { supportedKeys } from "@libp2p/crypto/keys";
-import { createPeerIdFromKeypair, generateKeypair, KeypairType } from "../../../src/keypair/index.js";
+import { createPeerIdFromKeypair, generateKeypair } from "../../../src/keypair/index.js";
 
 describe("createPeerIdFromKeypair", function () {
   it("should properly create a PeerId from a secp256k1 keypair with private key", async function () {
-    const keypair = generateKeypair(KeypairType.Secp256k1);
+    const keypair = generateKeypair("secp256k1");
     const privKey = new supportedKeys.secp256k1.Secp256k1PrivateKey(keypair.privateKey, keypair.publicKey);
 
     const expectedPeerId = await createFromPrivKey(privKey);
@@ -14,7 +14,7 @@ describe("createPeerIdFromKeypair", function () {
     expect(actualPeerId).to.be.deep.equal(expectedPeerId);
   });
   it("should properly create a PeerId from a secp256k1 keypair without private key", async function () {
-    const keypair = generateKeypair(KeypairType.Secp256k1);
+    const keypair = generateKeypair("secp256k1");
     delete (keypair as any)._privateKey;
     const pubKey = new supportedKeys.secp256k1.Secp256k1PublicKey(keypair.publicKey);
 

--- a/test/unit/keypair/index.test.ts
+++ b/test/unit/keypair/index.test.ts
@@ -1,25 +1,26 @@
 import { expect } from "chai";
 import { createFromPrivKey, createFromPubKey } from "@libp2p/peer-id-factory";
 import { supportedKeys } from "@libp2p/crypto/keys";
-import { createPeerIdFromKeypair, generateKeypair } from "../../../src/keypair/index.js";
+import { generateKeypair } from "../../../src/keypair/index.js";
+import { createPeerIdFromPrivateKey, createPeerIdFromPublicKey } from "../../../src/enr/index.js";
 
-describe("createPeerIdFromKeypair", function () {
-  it("should properly create a PeerId from a secp256k1 keypair with private key", async function () {
+describe("createPeerIdFromPrivateKey", function () {
+  it("should properly create a PeerId from a secp256k1 private key", async function () {
     const keypair = generateKeypair("secp256k1");
     const privKey = new supportedKeys.secp256k1.Secp256k1PrivateKey(keypair.privateKey, keypair.publicKey);
 
     const expectedPeerId = await createFromPrivKey(privKey);
-    const actualPeerId = await createPeerIdFromKeypair(keypair);
+    const actualPeerId = await createPeerIdFromPrivateKey(keypair.type, keypair.privateKey);
 
     expect(actualPeerId).to.be.deep.equal(expectedPeerId);
   });
-  it("should properly create a PeerId from a secp256k1 keypair without private key", async function () {
+  it("should properly create a PeerId from a secp256k1 public key", async function () {
     const keypair = generateKeypair("secp256k1");
     delete (keypair as any)._privateKey;
     const pubKey = new supportedKeys.secp256k1.Secp256k1PublicKey(keypair.publicKey);
 
     const expectedPeerId = await createFromPubKey(pubKey);
-    const actualPeerId = await createPeerIdFromKeypair(keypair);
+    const actualPeerId = await createPeerIdFromPublicKey(keypair.type, keypair.publicKey);
 
     expect(actualPeerId).to.be.deep.equal(expectedPeerId);
   });

--- a/test/unit/service/service.test.ts
+++ b/test/unit/service/service.test.ts
@@ -3,13 +3,13 @@ import { expect } from "chai";
 import { multiaddr } from "@multiformats/multiaddr";
 
 import { Discv5 } from "../../../src/service/service.js";
-import { SignableENR } from "../../../src/enr/index.js";
-import { generateKeypair, createPeerIdFromKeypair } from "../../../src/keypair/index.js";
+import { createPeerIdFromPrivateKey, SignableENR } from "../../../src/enr/index.js";
+import { generateKeypair } from "../../../src/keypair/index.js";
 
 describe("Discv5", async () => {
   const kp0 = generateKeypair("secp256k1");
-  const peerId0 = await createPeerIdFromKeypair(kp0);
-  const enr0 = SignableENR.createV4(kp0);
+  const peerId0 = await createPeerIdFromPrivateKey(kp0.type, kp0.privateKey);
+  const enr0 = SignableENR.createV4(kp0.privateKey);
   const mu0 = multiaddr("/ip4/127.0.0.1/udp/40000");
 
   const service0 = Discv5.create({ enr: enr0, peerId: peerId0, bindAddrs: { ip4: mu0 } });
@@ -32,7 +32,7 @@ describe("Discv5", async () => {
 
   it("should add new enrs", async () => {
     const kp1 = generateKeypair("secp256k1");
-    const enr1 = SignableENR.createV4(kp1);
+    const enr1 = SignableENR.createV4(kp1.privateKey);
     enr1.encode();
     service0.addEnr(enr1.toENR());
     expect(service0.kadValues().length).eq(1);
@@ -41,8 +41,8 @@ describe("Discv5", async () => {
   it("should complete a lookup to another node", async function () {
     this.timeout(10000);
     const kp1 = generateKeypair("secp256k1");
-    const peerId1 = await createPeerIdFromKeypair(kp1);
-    const enr1 = SignableENR.createV4(kp1);
+    const peerId1 = await createPeerIdFromPrivateKey(kp1.type, kp1.privateKey);
+    const enr1 = SignableENR.createV4(kp1.privateKey);
     const mu1 = multiaddr("/ip4/127.0.0.1/udp/10360");
     const addr1 = mu1.tuples();
 
@@ -57,7 +57,7 @@ describe("Discv5", async () => {
     await service1.start();
     for (let i = 0; i < 100; i++) {
       const kp = generateKeypair("secp256k1");
-      const enr = SignableENR.createV4(kp);
+      const enr = SignableENR.createV4(kp.privateKey);
       enr.encode();
       service1.addEnr(enr.toENR());
     }

--- a/test/unit/service/service.test.ts
+++ b/test/unit/service/service.test.ts
@@ -4,10 +4,10 @@ import { multiaddr } from "@multiformats/multiaddr";
 
 import { Discv5 } from "../../../src/service/service.js";
 import { SignableENR } from "../../../src/enr/index.js";
-import { generateKeypair, KeypairType, createPeerIdFromKeypair } from "../../../src/keypair/index.js";
+import { generateKeypair, createPeerIdFromKeypair } from "../../../src/keypair/index.js";
 
 describe("Discv5", async () => {
-  const kp0 = generateKeypair(KeypairType.Secp256k1);
+  const kp0 = generateKeypair("secp256k1");
   const peerId0 = await createPeerIdFromKeypair(kp0);
   const enr0 = SignableENR.createV4(kp0);
   const mu0 = multiaddr("/ip4/127.0.0.1/udp/40000");
@@ -31,7 +31,7 @@ describe("Discv5", async () => {
   });
 
   it("should add new enrs", async () => {
-    const kp1 = generateKeypair(KeypairType.Secp256k1);
+    const kp1 = generateKeypair("secp256k1");
     const enr1 = SignableENR.createV4(kp1);
     enr1.encode();
     service0.addEnr(enr1.toENR());
@@ -40,7 +40,7 @@ describe("Discv5", async () => {
 
   it("should complete a lookup to another node", async function () {
     this.timeout(10000);
-    const kp1 = generateKeypair(KeypairType.Secp256k1);
+    const kp1 = generateKeypair("secp256k1");
     const peerId1 = await createPeerIdFromKeypair(kp1);
     const enr1 = SignableENR.createV4(kp1);
     const mu1 = multiaddr("/ip4/127.0.0.1/udp/10360");
@@ -56,7 +56,7 @@ describe("Discv5", async () => {
     const service1 = Discv5.create({ enr: enr1, peerId: peerId1, bindAddrs: { ip4: mu1 } });
     await service1.start();
     for (let i = 0; i < 100; i++) {
-      const kp = generateKeypair(KeypairType.Secp256k1);
+      const kp = generateKeypair("secp256k1");
       const enr = SignableENR.createV4(kp);
       enr.encode();
       service1.addEnr(enr.toENR());

--- a/test/unit/session/crypto.test.ts
+++ b/test/unit/session/crypto.test.ts
@@ -13,7 +13,7 @@ import {
   decryptMessage,
 } from "../../../src/session/index.js";
 import { v4, SignableENR } from "../../../src/enr/index.js";
-import { KeypairType, createKeypair, generateKeypair } from "../../../src/keypair/index.js";
+import { createKeypair, generateKeypair } from "../../../src/keypair/index.js";
 import { createNodeContact } from "../../../src/session/nodeInfo.js";
 
 describe("session crypto", () => {
@@ -50,14 +50,14 @@ describe("session crypto", () => {
   });
 
   it("symmetric keys should be derived correctly", () => {
-    const kp1 = generateKeypair(KeypairType.Secp256k1);
-    const kp2 = generateKeypair(KeypairType.Secp256k1);
+    const kp1 = generateKeypair("secp256k1");
+    const kp2 = generateKeypair("secp256k1");
     const enr1 = SignableENR.createV4(kp1);
     const enr2 = SignableENR.createV4(kp2);
     const nonce = randomBytes(32);
     const [a1, b1, pk] = generateSessionKeys(enr1.nodeId, createNodeContact(enr2.toENR()), nonce);
     const [a2, b2] = deriveKeysFromPubkey(
-      createKeypair(KeypairType.Secp256k1, kp2.privateKey),
+      createKeypair("secp256k1", kp2.privateKey),
       enr2.nodeId,
       enr1.nodeId,
       pk,
@@ -82,16 +82,10 @@ describe("session crypto", () => {
     const ephemPK = Buffer.from("039961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231", "hex");
     const nodeIdB = "bbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9";
 
-    const actual = idSign(createKeypair(KeypairType.Secp256k1, localSK), challengeData, ephemPK, nodeIdB);
+    const actual = idSign(createKeypair("secp256k1", localSK), challengeData, ephemPK, nodeIdB);
     expect(actual).to.deep.equal(expected);
     expect(
-      idVerify(
-        createKeypair(KeypairType.Secp256k1, undefined, v4.publicKey(localSK)),
-        challengeData,
-        ephemPK,
-        nodeIdB,
-        actual
-      )
+      idVerify(createKeypair("secp256k1", undefined, v4.publicKey(localSK)), challengeData, ephemPK, nodeIdB, actual)
     ).to.be.true;
   });
 

--- a/test/unit/session/crypto.test.ts
+++ b/test/unit/session/crypto.test.ts
@@ -12,7 +12,7 @@ import {
   encryptMessage,
   decryptMessage,
 } from "../../../src/session/index.js";
-import { v4, SignableENR } from "../../../src/enr/index.js";
+import { getV4Crypto, SignableENR } from "../../../src/enr/index.js";
 import { createKeypair, generateKeypair } from "../../../src/keypair/index.js";
 import { createNodeContact } from "../../../src/session/nodeInfo.js";
 
@@ -52,17 +52,11 @@ describe("session crypto", () => {
   it("symmetric keys should be derived correctly", () => {
     const kp1 = generateKeypair("secp256k1");
     const kp2 = generateKeypair("secp256k1");
-    const enr1 = SignableENR.createV4(kp1);
-    const enr2 = SignableENR.createV4(kp2);
+    const enr1 = SignableENR.createV4(kp1.privateKey);
+    const enr2 = SignableENR.createV4(kp2.privateKey);
     const nonce = randomBytes(32);
     const [a1, b1, pk] = generateSessionKeys(enr1.nodeId, createNodeContact(enr2.toENR()), nonce);
-    const [a2, b2] = deriveKeysFromPubkey(
-      createKeypair("secp256k1", kp2.privateKey),
-      enr2.nodeId,
-      enr1.nodeId,
-      pk,
-      nonce
-    );
+    const [a2, b2] = deriveKeysFromPubkey(kp2, enr2.nodeId, enr1.nodeId, pk, nonce);
 
     expect(a1).to.deep.equal(a2);
     expect(b1).to.deep.equal(b2);
@@ -82,10 +76,16 @@ describe("session crypto", () => {
     const ephemPK = Buffer.from("039961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231", "hex");
     const nodeIdB = "bbbb9d047f0488c0b5a93c1c3f2d8bafc7c8ff337024a55434a0d0555de64db9";
 
-    const actual = idSign(createKeypair("secp256k1", localSK), challengeData, ephemPK, nodeIdB);
+    const actual = idSign(createKeypair({ type: "secp256k1", privateKey: localSK }), challengeData, ephemPK, nodeIdB);
     expect(actual).to.deep.equal(expected);
     expect(
-      idVerify(createKeypair("secp256k1", undefined, v4.publicKey(localSK)), challengeData, ephemPK, nodeIdB, actual)
+      idVerify(
+        createKeypair({ type: "secp256k1", publicKey: getV4Crypto().publicKey(localSK) }),
+        challengeData,
+        ephemPK,
+        nodeIdB,
+        actual
+      )
     ).to.be.true;
   });
 

--- a/test/unit/session/service.test.ts
+++ b/test/unit/session/service.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "chai";
 import { Multiaddr, multiaddr } from "@multiformats/multiaddr";
 
-import { createKeypair, KeypairType } from "../../../src/keypair/index.js";
+import { createKeypair } from "../../../src/keypair/index.js";
 import { SignableENR } from "../../../src/enr/index.js";
 import { createWhoAreYouPacket, IPacket, PacketType } from "../../../src/packet/index.js";
 import { UDPTransportService } from "../../../src/transport/index.js";
@@ -13,12 +13,12 @@ import { createNodeContact } from "../../../src/session/nodeInfo.js";
 
 describe("session service", () => {
   const kp0 = createKeypair(
-    KeypairType.Secp256k1,
+    "secp256k1",
     Buffer.from("a93bedf04784c937059557c9dcb328f5f59fdb6e89295c30e918579250b7b01f", "hex"),
     Buffer.from("022663242e1092ea19e6bb41d67aa69850541a623b94bbea840ddceaab39789894", "hex")
   );
   const kp1 = createKeypair(
-    KeypairType.Secp256k1,
+    "secp256k1",
     Buffer.from("bd04e55f2a1424a4e69e96aad41cf763d2468d4358472e9f851569bdf47fb24c", "hex"),
     Buffer.from("03eae9945b354e9212566bc3f2740f3a62b3e1eb227dbed809f6dc2d3ea848c82e", "hex")
   );

--- a/test/unit/session/service.test.ts
+++ b/test/unit/session/service.test.ts
@@ -12,22 +12,22 @@ import { defaultConfig } from "../../../src/config/index.js";
 import { createNodeContact } from "../../../src/session/nodeInfo.js";
 
 describe("session service", () => {
-  const kp0 = createKeypair(
-    "secp256k1",
-    Buffer.from("a93bedf04784c937059557c9dcb328f5f59fdb6e89295c30e918579250b7b01f", "hex"),
-    Buffer.from("022663242e1092ea19e6bb41d67aa69850541a623b94bbea840ddceaab39789894", "hex")
-  );
-  const kp1 = createKeypair(
-    "secp256k1",
-    Buffer.from("bd04e55f2a1424a4e69e96aad41cf763d2468d4358472e9f851569bdf47fb24c", "hex"),
-    Buffer.from("03eae9945b354e9212566bc3f2740f3a62b3e1eb227dbed809f6dc2d3ea848c82e", "hex")
-  );
+  const kp0 = createKeypair({
+    type: "secp256k1",
+    privateKey: Buffer.from("a93bedf04784c937059557c9dcb328f5f59fdb6e89295c30e918579250b7b01f", "hex"),
+    publicKey: Buffer.from("022663242e1092ea19e6bb41d67aa69850541a623b94bbea840ddceaab39789894", "hex"),
+  });
+  const kp1 = createKeypair({
+    type: "secp256k1",
+    privateKey: Buffer.from("bd04e55f2a1424a4e69e96aad41cf763d2468d4358472e9f851569bdf47fb24c", "hex"),
+    publicKey: Buffer.from("03eae9945b354e9212566bc3f2740f3a62b3e1eb227dbed809f6dc2d3ea848c82e", "hex"),
+  });
 
   const addr0 = multiaddr("/ip4/127.0.0.1/udp/49020");
   const addr1 = multiaddr("/ip4/127.0.0.1/udp/49021");
 
-  const enr0 = SignableENR.createV4(kp0);
-  const enr1 = SignableENR.createV4(kp1);
+  const enr0 = SignableENR.createV4(kp0.privateKey);
+  const enr1 = SignableENR.createV4(kp1.privateKey);
 
   enr0.setLocationMultiaddr(addr0);
   enr1.setLocationMultiaddr(addr1);

--- a/test/unit/util/ip.test.ts
+++ b/test/unit/util/ip.test.ts
@@ -1,6 +1,6 @@
 import { multiaddr } from "@multiformats/multiaddr";
 import { expect } from "chai";
-import { generateKeypair, KeypairType, SignableENR } from "../../../src/index.js";
+import { generateKeypair, SignableENR } from "../../../src/index.js";
 import {
   getSocketAddressOnENR,
   SocketAddress,
@@ -133,7 +133,7 @@ describe("get/set SocketAddress on ENR", () => {
       },
       port: 53,
     };
-    const enr = SignableENR.createV4(generateKeypair(KeypairType.Secp256k1));
+    const enr = SignableENR.createV4(generateKeypair("secp256k1"));
     expect(getSocketAddressOnENR(enr, { ip4: true, ip6: false })).to.equal(undefined);
 
     setSocketAddressOnENR(enr, addr);

--- a/test/unit/util/ip.test.ts
+++ b/test/unit/util/ip.test.ts
@@ -133,7 +133,7 @@ describe("get/set SocketAddress on ENR", () => {
       },
       port: 53,
     };
-    const enr = SignableENR.createV4(generateKeypair("secp256k1"));
+    const enr = SignableENR.createV4(generateKeypair("secp256k1").privateKey);
     expect(getSocketAddressOnENR(enr, { ip4: true, ip6: false })).to.equal(undefined);
 
     setSocketAddressOnENR(enr, addr);


### PR DESCRIPTION
This is a prerequisite towards pulling the enr code into a separate package.
The core change here is de-tangling the enr code from the rest of the discv5 code.

One consideration there is allowing the cryptography to be swapped out by consumers. Generally, the fastest crypto implementations aren't browser compatible, or are overkill when installing a package (requiring lengthy compilation step when npm intsalling).
A future PR will remove bcrypto as the default crypto impl.

BREAKING CHANGE:
- remove `enr.keypair`
- export enr v4 crypto from `getV4Crypto` function
- replace `createKeypairFromPeerId` and vice versa with `createPublicKeyFromPeerId`
- refactor `createKeypair`