### PR TITLE
feat!: remove broadcastTalkReq

### DIFF
--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -404,31 +404,6 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
   }
 
   /**
-   * Broadcast TALKREQ message to all nodes in routing table and returns response
-   */
-  public async broadcastTalkReq(payload: Buffer, protocol: string | Uint8Array): Promise<Buffer> {
-    return await new Promise((resolve, reject) => {
-      const request = createTalkRequestMessage(payload, protocol);
-      const callback = (err: RequestErrorType | null, res: Buffer | null): void => {
-        if (err) {
-          return reject(err);
-        }
-        if (res) {
-          resolve(res);
-        }
-      };
-
-      /** Broadcast request to all peers in the routing table */
-      for (const node of this.kadValues()) {
-        this.sendRpcRequest({
-          contact: createNodeContact(node),
-          request,
-          callback,
-        });
-      }
-    });
-  }
-  /**
    * Send TALKREQ message to dstId and returns response
    */
   public async sendTalkReq(remote: ENR | Multiaddr, payload: Buffer, protocol: string | Uint8Array): Promise<Buffer> {


### PR DESCRIPTION
BREAKING CHANGE:
`broadcastTalkReq` has been removed since it was very opinionated and can be trivially reproduced using `kadValues` and `sendTalkReq`.

```ts
function broadcastTalkReq(
  discv5: IDiscv5, payload: Buffer, protocol: string | Uint8Array
): Promise<Buffer> {
  const requests = []
  for (const enr of discv5.kadValues()) {
    requests.push(discv5.sendTalkReq(enr, payload, protocol)
  }
  // Depending on the use case
  // you might want to replace with Promise.allSettled
  // to return all responses / errors
  return Promise.race(requests)
}
```