### PR TITLE
fix: improve error handling

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,7 @@ module.exports = {
     "prefer-const": "error",
     "quotes": ["error", "double"],
     "@chainsafe/node/file-extension-in-import": ["error", "always", {esm: true}],
+    "@typescript-eslint/no-floating-promises": "error",
   },
   "overrides": [
     {

--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -462,7 +462,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
   private pingConnectedPeers(): void {
     for (const entry of this.kbuckets.rawValues()) {
       if (entry.status === EntryStatus.Connected) {
-        this.sendPing(entry.value);
+        this.sendPing(entry.value).catch((e) => log("Error pinging peer %o: %s", entry.value, (e as Error).message));
       }
     }
   }
@@ -548,7 +548,9 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
               setInterval(() => {
                 // If the node is in the routing table, keep pinging
                 if (this.kbuckets.getValue(nodeId)) {
-                  this.sendPing(newStatus.enr);
+                  this.sendPing(newStatus.enr).catch((e) =>
+                    log("Error pinging peer %o: %s", newStatus.enr, (e as Error).message)
+                  );
                 } else {
                   clearInterval(this.connectedPeers.get(nodeId) as NodeJS.Timeout);
                   this.connectedPeers.delete(nodeId);
@@ -569,7 +571,9 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
               setInterval(() => {
                 // If the node is in the routing table, keep pinging
                 if (this.kbuckets.getValue(nodeId)) {
-                  this.sendPing(newStatus.enr);
+                  this.sendPing(newStatus.enr).catch((e) =>
+                    log("Error pinging peer %o: %s", newStatus.enr, (e as Error).message)
+                  );
                 } else {
                   clearInterval(this.connectedPeers.get(nodeId) as NodeJS.Timeout);
                   this.connectedPeers.delete(nodeId);
@@ -682,7 +686,7 @@ export class Discv5 extends (EventEmitter as { new (): Discv5EventEmitter }) {
   // process kad updates
 
   private onPendingEviction = (enr: ENR): void => {
-    this.sendPing(enr);
+    this.sendPing(enr).catch((e) => log("Error pinging peer %o: %s", enr, (e as Error).message));
   };
 
   private onAppliedEviction = (inserted: ENR, evicted?: ENR): void => {

--- a/packages/discv5/src/service/types.ts
+++ b/packages/discv5/src/service/types.ts
@@ -57,7 +57,7 @@ export interface INodesResponse {
 /**
  * Active RPC request awaiting a response
  */
-export interface IActiveRequest<T extends RequestMessage = RequestMessage, U extends Callback = Callback> {
+export interface IActiveRequest<T extends RequestMessage = RequestMessage, U extends ResponseType = ResponseType> {
   /**
    * The address the request was sent to.
    */
@@ -73,19 +73,18 @@ export interface IActiveRequest<T extends RequestMessage = RequestMessage, U ext
   /**
    * Callback if this request was from a user level request.
    */
-  callback?: U;
+  callbackPromise?: {
+    resolve: (value: U) => void;
+    reject: (err: RequestErrorType) => void;
+  };
 }
 
-export type BufferCallback = (err: RequestErrorType | null, res: Buffer | null) => void;
-export type ENRCallback = (err: RequestErrorType | null, res: ENR[] | null) => void;
 export type PongResponse = {
   enrSeq: SequenceNumber;
   addr: SocketAddress;
 };
-export type PongCallback = (err: RequestErrorType | null, res: PongResponse | null) => void;
-export type Callback = BufferCallback | ENRCallback | PongCallback;
 
-export type CallbackResponseType = Buffer | ENR;
+export type ResponseType = Buffer | ENR[] | PongResponse;
 
 export enum ConnectionStatusType {
   Connected,

--- a/packages/discv5/src/service/types.ts
+++ b/packages/discv5/src/service/types.ts
@@ -3,7 +3,14 @@ import StrictEventEmitter from "strict-event-emitter-types";
 import { Multiaddr } from "@multiformats/multiaddr";
 import { ENR, SequenceNumber, SignableENR } from "@chainsafe/enr";
 
-import { ITalkReqMessage, ITalkRespMessage, RequestMessage } from "../message/index.js";
+import {
+  INodesMessage,
+  IPongMessage,
+  ITalkReqMessage,
+  ITalkRespMessage,
+  MessageType,
+  RequestMessage,
+} from "../message/index.js";
 import { INodeAddress, NodeContact } from "../session/nodeInfo.js";
 import { ConnectionDirection, RequestErrorType, ResponseErrorType } from "../session/index.js";
 import { SocketAddress } from "../util/ip.js";
@@ -95,6 +102,17 @@ export type PongResponse = {
 };
 
 export type ResponseType = Buffer | ENR[] | PongResponse;
+
+export function toResponseType(response: IPongMessage | INodesMessage | ITalkRespMessage): ResponseType {
+  switch (response.type) {
+    case MessageType.PONG:
+      return { enrSeq: response.enrSeq, addr: response.addr };
+    case MessageType.NODES:
+      return response.enrs;
+    case MessageType.TALKRESP:
+      return response.response;
+  }
+}
 
 export enum ConnectionStatusType {
   Connected,

--- a/packages/discv5/src/service/types.ts
+++ b/packages/discv5/src/service/types.ts
@@ -5,7 +5,7 @@ import { ENR, SequenceNumber, SignableENR } from "@chainsafe/enr";
 
 import { ITalkReqMessage, ITalkRespMessage, RequestMessage } from "../message/index.js";
 import { INodeAddress, NodeContact } from "../session/nodeInfo.js";
-import { ConnectionDirection, RequestErrorType } from "../session/index.js";
+import { ConnectionDirection, RequestErrorType, ResponseErrorType } from "../session/index.js";
 import { SocketAddress } from "../util/ip.js";
 
 export interface IDiscv5Events {
@@ -75,8 +75,18 @@ export interface IActiveRequest<T extends RequestMessage = RequestMessage, U ext
    */
   callbackPromise?: {
     resolve: (value: U) => void;
-    reject: (err: RequestErrorType) => void;
+    reject: (err: CodeError<RequestErrorType | ResponseErrorType>) => void;
   };
+}
+
+export class CodeError<T> extends Error {
+  code: T;
+
+  constructor(code: T, message?: string) {
+    super(message);
+
+    this.code = code;
+  }
 }
 
 export type PongResponse = {

--- a/packages/discv5/src/session/crypto.ts
+++ b/packages/discv5/src/session/crypto.ts
@@ -5,7 +5,6 @@ import { NodeId } from "@chainsafe/enr";
 
 import { generateKeypair, IKeypair, createKeypair } from "../keypair/index.js";
 import { fromHex } from "../util/index.js";
-import { getNodeId, getPublicKey, NodeContact } from "./nodeInfo.js";
 
 // Implementation for generating session keys in the Discv5 protocol.
 // Currently, Diffie-Hellman key agreement is performed with known public key types. Session keys
@@ -25,23 +24,19 @@ export const MAC_LENGTH = 16;
 // Returns [initiatorKey, responderKey, ephemPK]
 export function generateSessionKeys(
   localId: NodeId,
-  remoteContact: NodeContact,
+  remoteId: NodeId,
+  remotePubkey: IKeypair,
   challengeData: Buffer
 ): [Buffer, Buffer, Buffer] {
-  const remoteKeypair = getPublicKey(remoteContact);
-  const ephemKeypair = generateKeypair(remoteKeypair.type);
-  const secret = ephemKeypair.deriveSecret(remoteKeypair);
+  const ephemKeypair = generateKeypair(remotePubkey.type);
+  const secret = ephemKeypair.deriveSecret(remotePubkey);
   /* TODO possibly not needed, check tests
   const ephemPubkey =
     remoteKeypair.type === "secp256k1"
       ? secp256k1PublicKeyToCompressed(ephemKeypair.publicKey)
       : ephemKeypair.publicKey;
   */
-  return [...deriveKey(secret, localId, getNodeId(remoteContact), challengeData), ephemKeypair.publicKey] as [
-    Buffer,
-    Buffer,
-    Buffer
-  ];
+  return [...deriveKey(secret, localId, remoteId, challengeData), ephemKeypair.publicKey] as [Buffer, Buffer, Buffer];
 }
 
 export function deriveKey(secret: Buffer, firstId: NodeId, secondId: NodeId, challengeData: Buffer): [Buffer, Buffer] {

--- a/packages/discv5/src/session/service.ts
+++ b/packages/discv5/src/session/service.ts
@@ -847,6 +847,8 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
   }
 
   private send(nodeAddr: INodeAddress, packet: IPacket): void {
-    this.transport.send(nodeAddr.socketAddr, nodeAddr.nodeId, packet);
+    this.transport
+      .send(nodeAddr.socketAddr, nodeAddr.nodeId, packet)
+      .catch((e) => log("Error sending packet to node %o: %s", nodeAddr, (e as Error).message));
   }
 }

--- a/packages/discv5/src/session/service.ts
+++ b/packages/discv5/src/session/service.ts
@@ -150,7 +150,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
     this.transport = transport;
 
     this.activeRequests = new TimeoutMap(config.requestTimeout, (k, v) =>
-      this.handleRequestTimeout(getNodeAddress(v.contact, this.ipMode), v)
+      this.handleRequestTimeout(getNodeAddress(v.contact), v)
     );
     this.activeRequestsNonceMapping = new Map();
     this.pendingRequests = new Map();
@@ -190,7 +190,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    * Sends an RequestMessage to a node.
    */
   public sendRequest(contact: NodeContact, request: RequestMessage): void {
-    const nodeAddr = getNodeAddress(contact, this.ipMode);
+    const nodeAddr = getNodeAddress(contact);
     const nodeAddrStr = nodeAddressToString(nodeAddr);
 
     if (this.transport.bindAddrs.some((bindAddr) => nodeAddr.socketAddr.equals(bindAddr))) {
@@ -745,7 +745,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
    * Inserts a request and associated authTag mapping
    */
   private insertActiveRequest(requestCall: IRequestCall): void {
-    const nodeAddr = getNodeAddress(requestCall.contact, this.ipMode);
+    const nodeAddr = getNodeAddress(requestCall.contact);
     const nodeAddrStr = nodeAddressToString(nodeAddr);
     this.activeRequestsNonceMapping.set(requestCall.packet.header.nonce.toString("hex"), nodeAddr);
     this.activeRequests.set(nodeAddrStr, requestCall);
@@ -823,7 +823,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
     // Fail the current request
     this.emit("requestFailed", requestCall.request.id, error);
 
-    const nodeAddr = getNodeAddress(requestCall.contact, this.ipMode);
+    const nodeAddr = getNodeAddress(requestCall.contact);
     this.failSession(nodeAddr, error, removeSession);
   }
 

--- a/packages/discv5/src/session/session.ts
+++ b/packages/discv5/src/session/session.ts
@@ -22,7 +22,7 @@ import { IKeypair, createKeypair } from "../keypair/index.js";
 import { randomBytes } from "crypto";
 import { RequestId } from "../message/index.js";
 import { IChallenge } from ".";
-import { getNodeId, NodeContact } from "./nodeInfo.js";
+import { getNodeId, getPublicKey, NodeContact } from "./nodeInfo.js";
 
 // The `Session` struct handles the stages of creating and establishing a handshake with a
 // peer.
@@ -136,7 +136,12 @@ export class Session {
     message: Buffer
   ): [IPacket, Session] {
     // generate session keys
-    const [encryptionKey, decryptionKey, ephPubkey] = generateSessionKeys(localNodeId, remoteContact, challengeData);
+    const [encryptionKey, decryptionKey, ephPubkey] = generateSessionKeys(
+      localNodeId,
+      getNodeId(remoteContact),
+      getPublicKey(remoteContact),
+      challengeData
+    );
     const keys = { encryptionKey, decryptionKey };
 
     // construct nonce signature

--- a/packages/discv5/src/session/types.ts
+++ b/packages/discv5/src/session/types.ts
@@ -57,6 +57,14 @@ export enum RequestErrorType {
   InvalidMultiaddr,
 }
 
+export enum ResponseErrorType {
+  /** The responder address does not match the expected address */
+  WrongAddress,
+  /** The response type does not match the expected response type */
+  WrongResponseType,
+  /** The response handler threw */
+  InternalError,
+}
 export interface IKeys {
   encryptionKey: Buffer;
   decryptionKey: Buffer;

--- a/packages/discv5/test/e2e/connect.test.ts
+++ b/packages/discv5/test/e2e/connect.test.ts
@@ -80,7 +80,7 @@ describe("discv5 integration test", function () {
     // test a TALKRESP with a response
     const expectedResp = Buffer.from([4, 5, 6, 7]);
     node1.discv5.on("talkReqReceived", (nodeAddr, enr, request) => {
-      node1.discv5.sendTalkResp(nodeAddr, request.id, expectedResp);
+      void node1.discv5.sendTalkResp(nodeAddr, request.id, expectedResp);
     });
     const resp = await node0.discv5.sendTalkReq(node1.enr.toENR(), Buffer.from([0, 1, 2, 3]), "foo");
     expect(resp).to.deep.equal(expectedResp);

--- a/packages/discv5/test/unit/session/crypto.test.ts
+++ b/packages/discv5/test/unit/session/crypto.test.ts
@@ -14,7 +14,6 @@ import {
   decryptMessage,
 } from "../../../src/session/index.js";
 import { createKeypair, generateKeypair } from "../../../src/keypair/index.js";
-import { createNodeContact } from "../../../src/session/nodeInfo.js";
 
 describe("session crypto", () => {
   it("ecdh should produce expected secret", () => {
@@ -55,7 +54,12 @@ describe("session crypto", () => {
     const enr1 = SignableENR.createV4(kp1.privateKey);
     const enr2 = SignableENR.createV4(kp2.privateKey);
     const nonce = randomBytes(32);
-    const [a1, b1, pk] = generateSessionKeys(enr1.nodeId, createNodeContact(enr2.toENR()), nonce);
+    const [a1, b1, pk] = generateSessionKeys(
+      enr1.nodeId,
+      enr2.nodeId,
+      createKeypair({ type: enr2.keypairType, publicKey: enr2.publicKey }),
+      nonce
+    );
     const [a2, b2] = deriveKeysFromPubkey(kp2, enr2.nodeId, enr1.nodeId, pk, nonce);
 
     expect(a1).to.deep.equal(a2);

--- a/packages/discv5/test/unit/session/service.test.ts
+++ b/packages/discv5/test/unit/session/service.test.ts
@@ -84,7 +84,7 @@ describe("session service", () => {
         resolve();
       })
     );
-    service0.sendRequest(createNodeContact(enr1.toENR()), createFindNodeMessage([0]));
+    service0.sendRequest(createNodeContact(enr1.toENR(), { ip4: true, ip6: true }), createFindNodeMessage([0]));
     await Promise.all([receivedRandom, receivedWhoAreYou, establishedSession, receivedMsg]);
   });
   it("receiver should drop WhoAreYou packets from destinations without existing pending requests", async () => {

--- a/packages/discv5/test/unit/session/service.test.ts
+++ b/packages/discv5/test/unit/session/service.test.ts
@@ -88,7 +88,7 @@ describe("session service", () => {
     await Promise.all([receivedRandom, receivedWhoAreYou, establishedSession, receivedMsg]);
   });
   it("receiver should drop WhoAreYou packets from destinations without existing pending requests", async () => {
-    transport0.send(addr1, enr1.nodeId, createWhoAreYouPacket(Buffer.alloc(12), BigInt(0)));
+    void transport0.send(addr1, enr1.nodeId, createWhoAreYouPacket(Buffer.alloc(12), BigInt(0)));
     transport0.on("packet", () => expect.fail("transport0 should not receive any packets"));
   });
   it("should only accept WhoAreYou packets from destinations with existing pending requests", async () => {


### PR DESCRIPTION
## Motivation
- https://github.com/ChainSafe/discv5/issues/265
- https://github.com/ChainSafe/lodestar/issues/6320

## Notes
- refactor callback handling
  - move from callback style `(err, resp) => void` to deferred promise style `{resolve: (err) => void, reject: (err) => void}`
  - ensure callbacks are called in each rpc handler and in each error case
- remove hanging promises
  - add linter rule to ensure nothing remaining
- move error handling of node contacts into `getNodeContact` rather than the `getNodeAddress` "getter"
  - this makes error handling much more predictable, throwing upfront, rather than waiting for a later event to trigger an error
- wrap rpc handlers in try/catch statements
  - ensure that logic handed in rpc request and response handlers are unable to trigger unhandled exceptions