### PR TITLE
fix: @libp2p/crypto publicKey creation

### DIFF
--- a/packages/discv5/package.json
+++ b/packages/discv5/package.json
@@ -67,8 +67,8 @@
   "devDependencies": {},
   "dependencies": {
     "@chainsafe/enr": "^4.0.0",
-    "@libp2p/crypto": "^5.0.0",
-    "@libp2p/interface": "^2.0.0",
+    "@libp2p/crypto": "^5.0.1",
+    "@libp2p/interface": "^2.0.1",
     "@multiformats/multiaddr": "^12.1.10",
     "bcrypto": "^5.4.0",
     "bigint-buffer": "^1.1.5",

--- a/packages/enr/package.json
+++ b/packages/enr/package.json
@@ -53,9 +53,9 @@
     "@types/bn.js": "^4.11.5"
   },
   "dependencies": {
-    "@libp2p/crypto": "^5.0.0",
-    "@libp2p/interface": "^2.0.0",
-    "@libp2p/peer-id": "^5.0.0",
+    "@libp2p/crypto": "^5.0.1",
+    "@libp2p/interface": "^2.0.1",
+    "@libp2p/peer-id": "^5.0.1",
     "@multiformats/multiaddr": "^12.1.10",
     "bigint-buffer": "^1.1.5",
     "ethereum-cryptography": "^2.2.0",

--- a/packages/enr/test/unit/enr.test.ts
+++ b/packages/enr/test/unit/enr.test.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { generateKeyPair } from "@libp2p/crypto/keys";
 import { multiaddr } from "@multiformats/multiaddr";
 import { BaseENR, ENR, SignableENR, getV4Crypto } from "../../src/index.js";
+import { peerIdFromString } from "@libp2p/peer-id";
 
 const toHex = (buf: Uint8Array): string => Buffer.from(buf).toString("hex");
 
@@ -221,6 +222,14 @@ describe("ENR multiaddr support", () => {
       expect(enr.getLocationMultiaddr("quic")).to.deep.equal(multiaddr(`/ip4/${ip4}/udp/${quic}/quic-v1`));
       enr.ip6 = ip6;
     });
+  });
+
+  it("should properly get enr peer id", async () => {
+    const expectedPeerId = peerIdFromString("16Uiu2HAm5rokhpCBU7yBJHhMKXZ1xSVWwUcPMrzGKvU5Y7iBkmuK");
+    const enr = ENR.decodeTxt(
+      "enr:-LK4QDiPGwNomqUqNDaM3iHYvtdX7M5qngson6Qb2xGIg1LwC8-Nic0aQwO0rVbJt5xp32sRE3S1YqvVrWO7OgVNv0kBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpA7CIeVAAAgCf__________gmlkgnY0gmlwhBKNA4qJc2VjcDI1NmsxoQKbBS4ROQ_sldJm5tMgi36qm5I5exKJFb4C8dDVS_otAoN0Y3CCIyiDdWRwgiMo"
+    );
+    expect(enr.peerId.toString()).to.deep.equal(expectedPeerId.toString());
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,12 +537,12 @@
     yargs "16.2.0"
     yargs-parser "20.2.4"
 
-"@libp2p/crypto@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@libp2p/crypto/-/crypto-5.0.0.tgz#708a7a4d227593cffe3ba819d42cf217523142af"
-  integrity sha512-qU3D2jApJNIp0VMZ2B2QhZ1PK9sTnc4WTQ7NZ/LbZC9hDfeqZlviHhgwWzy0L6d7P0ScDi+XdIX5zxxugOL6DA==
+"@libp2p/crypto@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@libp2p/crypto/-/crypto-5.0.1.tgz#1cab80febd95d1393e1dd8ec4596f48a9eb85ffa"
+  integrity sha512-j7X4ISdWHnIJh752bl70z+3R4LdB8xftFU0ShOuuHg9ETTViHa3O0AK5v1HxyaSXE/uhXhfwjVH3vxn8ECQl/A==
   dependencies:
-    "@libp2p/interface" "^2.0.0"
+    "@libp2p/interface" "^2.0.1"
     "@noble/curves" "^1.4.0"
     "@noble/hashes" "^1.4.0"
     asn1js "^3.0.5"
@@ -551,10 +551,10 @@
     uint8arraylist "^2.4.8"
     uint8arrays "^5.1.0"
 
-"@libp2p/interface@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-2.0.0.tgz#bcec0c4e347516f31fd4e08ede40f5fde0eddc35"
-  integrity sha512-NaPyfEFcxRzu3jL3z3lsX84+Dvnu9RpeHI9SjdYvcsEnIQbRllDgA9rmA8SnQkyNKlW9V37UkXAQCQnIaOvT1Q==
+"@libp2p/interface@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-2.0.1.tgz#009475e222390396eec0f7c35bf5763049a03e09"
+  integrity sha512-zDAgu+ZNiYZxVsmcvCeNCLMnGORwLMMI8w0k2YcHwolATsv2q7QG3KpakmyKjH4m7C0hT86lGgf1sgGobPssYA==
   dependencies:
     "@multiformats/multiaddr" "^12.2.3"
     it-pushable "^3.2.3"
@@ -563,13 +563,13 @@
     progress-events "^1.0.0"
     uint8arraylist "^2.4.8"
 
-"@libp2p/peer-id@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@libp2p/peer-id/-/peer-id-5.0.0.tgz#39f8b702437e0cd4f89881145bb2a53e1fd8456c"
-  integrity sha512-1niX7fZJsOXKCs0UtArtgmNbEHkO6MDA/IfAZ84wBW/qAvdXbvxqYazWYKBfTRrD+3MG1GQ5l3MR8ciRx8pyyg==
+"@libp2p/peer-id@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@libp2p/peer-id/-/peer-id-5.0.1.tgz#b71b857906f5af19370d38fc9dc7a1cb321e0844"
+  integrity sha512-HwoW7dQ/o4NQ+5PQThOzMK2OHMRicmTZxVuMjbjWcPNnNWb8x/5vwjzdEUfqXimHYdZTIpy2PMMq6Jf4zvculQ==
   dependencies:
-    "@libp2p/crypto" "^5.0.0"
-    "@libp2p/interface" "^2.0.0"
+    "@libp2p/crypto" "^5.0.1"
+    "@libp2p/interface" "^2.0.1"
     multiformats "^13.1.0"
     uint8arrays "^5.1.0"
 


### PR DESCRIPTION
- publicKeyFromRaw was bugged for secp256k1 keys - see https://github.com/libp2p/js-libp2p/pull/2697
- Add test case that failed before upgrade
- Upgrade libp2p deps