### PR TITLE
fix:  BigInt conversion bug

### DIFF
--- a/packages/enr/src/util.ts
+++ b/packages/enr/src/util.ts
@@ -32,5 +32,8 @@ export function bigintToBytes(n: bigint): Uint8Array {
 }
 
 export function bytesToBigint(bytes: Uint8Array): bigint {
+  if (bytes.length === 0) {
+    return 0n;
+  }
   return BigInt(`0x${bytesToHex(bytes)}`);
 }

--- a/packages/enr/src/util.ts
+++ b/packages/enr/src/util.ts
@@ -33,7 +33,7 @@ export function bigintToBytes(n: bigint): Uint8Array {
 
 export function bytesToBigint(bytes: Uint8Array): bigint {
   if (bytes.length === 0) {
-    return 0n;
+    return BigInt(0);
   }
   return BigInt(`0x${bytesToHex(bytes)}`);
 }


### PR DESCRIPTION
This is a fix for a bug in the `ENR` package that was causing discv5 errors in ultralight. 

`enr/src/util.ts` exports a helper function `bytesToBigInt(bytes: Uint8Array): bigint`

This function uses `bytesToHex` from `ethereum-cryptography/utils` to convert the `Uint8Array` to a hex string, and then `BigInt()` to convert the hex string to `bigint`.

The bug occurs when the length of `bytes` is 0.  `bytesToHex` returns an empty string, and trying to call `BigInt('0x')` throws an error.

Fix: simply return `0n` if `bytes.length === 0`