### PR TITLE
fix: SessionService should send challenge even with active challenge

### DIFF
--- a/packages/discv5/src/session/service.ts
+++ b/packages/discv5/src/session/service.ts
@@ -275,11 +275,6 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
   public sendChallenge(nodeAddr: INodeAddress, nonce: Uint8Array, remoteEnr: ENR | null): void {
     const nodeAddrStr = nodeAddressToString(nodeAddr);
 
-    if (this.activeChallenges.peek(nodeAddrStr)) {
-      log("WHOAREYOU already sent. %o", nodeAddr);
-      return;
-    }
-
     // Ignore this request if the session is already established
     if (this.sessions.get(nodeAddrStr)) {
       log("Session already established. WHOAREYOU not sent to %o", nodeAddr);


### PR DESCRIPTION
Fix for failing hive test [PingHandshakeInterrupted](https://portal-hive-experimental.ethdevops.io/suite.html?suiteid=1744230445-096c31f89428ef5aa5e2c28dc5b7cffe.json&suitename=discv5#test-5) 

**Test `PingHandshakeInterrupted` starts a handshake, but doesn't finish it and sends a second ordinary message
 packet instead of a handshake message packet. The remote node should respond with
 another WHOAREYOU challenge for the second packet.**

----

`@chainsafe/discv5` fails to do this.  The `sendChallenge` method is called,  but first checks to see if we already sent a challenge, and if so, simply returns without sending a new challenge.

This PR removes the condition from `sessionService.sendChallenge` which prevents a new challenge from being sent.  The new challenge simply replaces the old one in `this.activeChallenges`.

This allows the hive test linked above to pass.  Actually, it allows the test to fail for a different reason, detailed in #309 .  When combined with a solution to the id encoding issue here: #312, the PingHandshakeInterrupted test passes.