### PR TITLE
fix: leading zeros stripped from request id

### DIFF
--- a/packages/discv5/src/message/create.ts
+++ b/packages/discv5/src/message/create.ts
@@ -1,5 +1,5 @@
 import { randomBytes, toBytes } from "@noble/hashes/utils";
-import { bytesToBigint, SequenceNumber, ENR } from "@chainsafe/enr";
+import { SequenceNumber, ENR } from "@chainsafe/enr";
 
 import {
   RequestId,
@@ -12,7 +12,7 @@ import {
 } from "./types.js";
 
 export function createRequestId(): RequestId {
-  return bytesToBigint(randomBytes(8));
+  return randomBytes(8);
 }
 
 export function createPingMessage(enrSeq: SequenceNumber): IPingMessage {

--- a/packages/discv5/src/message/decode.ts
+++ b/packages/discv5/src/message/decode.ts
@@ -53,7 +53,7 @@ function decodePing(data: Uint8Array): IPingMessage {
   }
   return {
     type: MessageType.PING,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     enrSeq: bytesToBigint(rlpRaw[1]),
   };
 }
@@ -78,7 +78,7 @@ function decodePong(data: Uint8Array): IPongMessage {
 
   return {
     type: MessageType.PONG,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     enrSeq: bytesToBigint(rlpRaw[1]),
     addr: { ip, port },
   };
@@ -95,7 +95,7 @@ function decodeFindNode(data: Uint8Array): IFindNodeMessage {
   const distances = (rlpRaw[1] as Uint8Array[]).map((x) => (x.length ? Number(bytesToBigint(x)) : 0));
   return {
     type: MessageType.FINDNODE,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     distances,
   };
 }
@@ -107,7 +107,7 @@ function decodeNodes(data: Uint8Array): INodesMessage {
   }
   return {
     type: MessageType.NODES,
-    id: bytesToBigint(rlpRaw[0] as Uint8Array),
+    id: rlpRaw[0] as Uint8Array,
     total: rlpRaw[1].length ? Number(bytesToBigint(rlpRaw[1] as Uint8Array)) : 0,
     enrs: rlpRaw[2].map((enrRaw) => ENR.decodeFromValues(enrRaw as Uint8Array[])),
   };
@@ -120,7 +120,7 @@ function decodeTalkReq(data: Uint8Array): ITalkReqMessage {
   }
   return {
     type: MessageType.TALKREQ,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     protocol: rlpRaw[1],
     request: rlpRaw[2],
   };
@@ -133,7 +133,7 @@ function decodeTalkResp(data: Uint8Array): ITalkRespMessage {
   }
   return {
     type: MessageType.TALKRESP,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     response: rlpRaw[1],
   };
 }
@@ -145,7 +145,7 @@ function decodeRegTopic(data: Uint8Array): IRegTopicMessage {
   }
   return {
     type: MessageType.REGTOPIC,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     topic: rlpRaw[1],
     enr: ENR.decodeFromValues(rlpRaw[2] as Uint8Array[]),
     ticket: rlpRaw[3],
@@ -159,7 +159,7 @@ function decodeTicket(data: Uint8Array): ITicketMessage {
   }
   return {
     type: MessageType.TICKET,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     ticket: rlpRaw[1],
     waitTime: rlpRaw[2].length ? Number(bytesToBigint(rlpRaw[2] as Uint8Array)) : 0,
   };
@@ -172,7 +172,7 @@ function decodeRegConfirmation(data: Uint8Array): IRegConfirmationMessage {
   }
   return {
     type: MessageType.REGCONFIRMATION,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     topic: rlpRaw[1],
   };
 }
@@ -184,7 +184,7 @@ function decodeTopicQuery(data: Uint8Array): ITopicQueryMessage {
   }
   return {
     type: MessageType.TOPICQUERY,
-    id: bytesToBigint(rlpRaw[0]),
+    id: rlpRaw[0],
     topic: rlpRaw[1],
   };
 }

--- a/packages/discv5/src/message/encode.ts
+++ b/packages/discv5/src/message/encode.ts
@@ -43,7 +43,7 @@ export function encode(message: Message): Uint8Array {
 }
 
 export function encodePingMessage(m: IPingMessage): Uint8Array {
-  return concatBytes(Uint8Array.from([MessageType.PING]), RLP.encode([bigintToBytes(m.id), bigintToBytes(m.enrSeq)]));
+  return concatBytes(Uint8Array.from([MessageType.PING]), RLP.encode([m.id, bigintToBytes(m.enrSeq)]));
 }
 
 export function encodePongMessage(m: IPongMessage): Uint8Array {
@@ -52,44 +52,44 @@ export function encodePongMessage(m: IPongMessage): Uint8Array {
   }
   return concatBytes(
     Uint8Array.from([MessageType.PONG]),
-    RLP.encode([bigintToBytes(m.id), bigintToBytes(m.enrSeq), ipToBytes(m.addr.ip), m.addr.port])
+    RLP.encode([m.id, bigintToBytes(m.enrSeq), ipToBytes(m.addr.ip), m.addr.port])
   );
 }
 
 export function encodeFindNodeMessage(m: IFindNodeMessage): Uint8Array {
-  return concatBytes(Uint8Array.from([MessageType.FINDNODE]), RLP.encode([bigintToBytes(m.id), m.distances]));
+  return concatBytes(Uint8Array.from([MessageType.FINDNODE]), RLP.encode([m.id, m.distances]));
 }
 
 export function encodeNodesMessage(m: INodesMessage): Uint8Array {
   return concatBytes(
     Uint8Array.from([MessageType.NODES]),
-    RLP.encode([bigintToBytes(m.id), m.total, m.enrs.map((enr) => enr.encodeToValues())])
+    RLP.encode([m.id, m.total, m.enrs.map((enr) => enr.encodeToValues())])
   );
 }
 
 export function encodeTalkReqMessage(m: ITalkReqMessage): Uint8Array {
-  return concatBytes(Uint8Array.from([MessageType.TALKREQ]), RLP.encode([bigintToBytes(m.id), m.protocol, m.request]));
+  return concatBytes(Uint8Array.from([MessageType.TALKREQ]), RLP.encode([m.id, m.protocol, m.request]));
 }
 
 export function encodeTalkRespMessage(m: ITalkRespMessage): Uint8Array {
-  return concatBytes(Uint8Array.from([MessageType.TALKRESP]), RLP.encode([bigintToBytes(m.id), m.response]));
+  return concatBytes(Uint8Array.from([MessageType.TALKRESP]), RLP.encode([m.id, m.response]));
 }
 
 export function encodeRegTopicMessage(m: IRegTopicMessage): Uint8Array {
   return concatBytes(
     Uint8Array.from([MessageType.REGTOPIC]),
-    RLP.encode([bigintToBytes(m.id), m.topic, m.enr.encodeToValues(), m.ticket])
+    RLP.encode([m.id, m.topic, m.enr.encodeToValues(), m.ticket])
   );
 }
 
 export function encodeTicketMessage(m: ITicketMessage): Uint8Array {
-  return concatBytes(Uint8Array.from([MessageType.TICKET]), RLP.encode([bigintToBytes(m.id), m.ticket, m.waitTime]));
+  return concatBytes(Uint8Array.from([MessageType.TICKET]), RLP.encode([m.id, m.ticket, m.waitTime]));
 }
 
 export function encodeRegConfirmMessage(m: IRegConfirmationMessage): Uint8Array {
-  return concatBytes(Uint8Array.from([MessageType.REGCONFIRMATION]), RLP.encode([bigintToBytes(m.id), m.topic]));
+  return concatBytes(Uint8Array.from([MessageType.REGCONFIRMATION]), RLP.encode([m.id, m.topic]));
 }
 
 export function encodeTopicQueryMessage(m: ITopicQueryMessage): Uint8Array {
-  return concatBytes(Uint8Array.from([MessageType.TOPICQUERY]), RLP.encode([bigintToBytes(m.id), m.topic]));
+  return concatBytes(Uint8Array.from([MessageType.TOPICQUERY]), RLP.encode([m.id, m.topic]));
 }

--- a/packages/discv5/src/message/types.ts
+++ b/packages/discv5/src/message/types.ts
@@ -1,7 +1,7 @@
 import { SequenceNumber, ENR } from "@chainsafe/enr";
 import { SocketAddress } from "../util/ip.js";
 
-export type RequestId = bigint;
+export type RequestId = Uint8Array;
 
 export type NodeAddressIP = {
   family: 4 | 6;

--- a/packages/discv5/src/session/service.ts
+++ b/packages/discv5/src/session/service.ts
@@ -643,7 +643,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
       // Check if this response matches these
       const requestId = session.awaitingEnr;
       if (requestId !== undefined) {
-        if (requestId === message.id) {
+        if (equalsBytes(requestId, message.id)) {
           delete session.awaitingEnr;
           if (message.type === MessageType.NODES) {
             // Received the requested ENR
@@ -696,7 +696,7 @@ export class SessionService extends (EventEmitter as { new (): StrictEventEmitte
       return;
     }
 
-    if (requestCall.request.id !== response.id) {
+    if (!equalsBytes(requestCall.request.id, response.id)) {
       log("Received an RPC Response to an unknown request. Likely late response. %o", nodeAddr);
       return;
     }

--- a/packages/discv5/src/session/types.ts
+++ b/packages/discv5/src/session/types.ts
@@ -2,7 +2,7 @@ import { Multiaddr } from "@multiformats/multiaddr";
 import { NodeId, ENR } from "@chainsafe/enr";
 
 import { IPacket } from "../packet/index.js";
-import { RequestMessage, ResponseMessage } from "../message/index.js";
+import { RequestId, RequestMessage, ResponseMessage } from "../message/index.js";
 import { INodeAddress, NodeContact } from "./nodeInfo.js";
 
 export type NodeAddressString = string;
@@ -152,5 +152,5 @@ export interface ISessionEvents {
   /**
    * An RPC request failed.
    */
-  requestFailed: (requestId: bigint, error: RequestErrorType) => void;
+  requestFailed: (requestId: RequestId, error: RequestErrorType) => void;
 }

--- a/packages/discv5/test/unit/message/codec.test.ts
+++ b/packages/discv5/test/unit/message/codec.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { ENR } from "@chainsafe/enr";
+import { bigintToBytes, ENR } from "@chainsafe/enr";
 import { Message, MessageType, decode, encode } from "../../../src/message/index.js";
 import { hexToBytes } from "ethereum-cryptography/utils.js";
 
@@ -11,7 +11,7 @@ describe("message", () => {
     {
       message: {
         type: MessageType.PING,
-        id: 1n,
+        id: bigintToBytes(1n),
         enrSeq: 1n,
       },
       expected: hexToBytes("01c20101"),
@@ -19,7 +19,7 @@ describe("message", () => {
     {
       message: {
         type: MessageType.PING,
-        id: 1n,
+        id: bigintToBytes(1n),
         enrSeq: 0n, // < test 0 enrSeq
       },
       expected: hexToBytes("01c20100"),
@@ -27,7 +27,7 @@ describe("message", () => {
     {
       message: {
         type: MessageType.PONG,
-        id: 1n,
+        id: bigintToBytes(1n),
         enrSeq: 1n,
         addr: { ip: { type: 4, octets: new Uint8Array([127, 0, 0, 1]) }, port: 255 }, // 1 byte
       },
@@ -36,7 +36,7 @@ describe("message", () => {
     {
       message: {
         type: MessageType.PONG,
-        id: 1n,
+        id: bigintToBytes(1n),
         enrSeq: 1n,
         addr: { ip: { type: 4, octets: new Uint8Array([127, 0, 0, 1]) }, port: 5000 },
       },
@@ -45,7 +45,7 @@ describe("message", () => {
     {
       message: {
         type: MessageType.PONG,
-        id: 1n,
+        id: bigintToBytes(1n),
         enrSeq: 1n,
         addr: { ip: { type: 6, octets: new Uint8Array(16).fill(0xaa) }, port: 5000 }, // 2 bytes
       },
@@ -54,7 +54,7 @@ describe("message", () => {
     {
       message: {
         type: MessageType.FINDNODE,
-        id: 1n,
+        id: bigintToBytes(1n),
         distances: [250],
       },
       expected: hexToBytes("03c401c281fa"),
@@ -62,7 +62,7 @@ describe("message", () => {
     {
       message: {
         type: MessageType.NODES,
-        id: 1n,
+        id: bigintToBytes(1n),
         total: 1,
         enrs: [],
       },
@@ -71,7 +71,7 @@ describe("message", () => {
     {
       message: {
         type: MessageType.NODES,
-        id: 1n,
+        id: bigintToBytes(1n),
         total: 1,
         enrs: [
           ENR.decodeTxt(
@@ -107,7 +107,7 @@ describe("invalid messages", () => {
     {
       message: {
         type: MessageType.PONG,
-        id: 1n,
+        id: bigintToBytes(1n),
         enrSeq: 1n,
         // Negative port is invalid.
         addr: { ip: { type: 4, octets: new Uint8Array([127, 0, 0, 1]) }, port: -1 },
@@ -117,7 +117,7 @@ describe("invalid messages", () => {
     {
       message: {
         type: MessageType.PONG,
-        id: 1n,
+        id: bigintToBytes(1n),
         enrSeq: 1n,
         // This port is greater than 16 bits.
         addr: { ip: { type: 4, octets: new Uint8Array([127, 0, 0, 1]) }, port: 65536 },


### PR DESCRIPTION
Fix for issue #309 

This is a fix for a number of hive tests.  Here is an [example](https://portal-hive-experimental.ethdevops.io/suite.html?suiteid=1744230445-096c31f89428ef5aa5e2c28dc5b7cffe.json&suitename=discv5#test-6)

The tests fail with errors like this:
` wrong request ID 01 in TALKRESP, want 00000001`

----

This is happening because when we `decode` an incoming `TalkRequest`, we store the `request.id` in memory as a `bigint`, using a `bytesToBigint` conversion.  

Then when we `encode` the `TalkResponse`, we convert the `request.id` back from a `bigint` to bytes using `bigintToBytes`.  

The requesting node compares the `response.id` to the `request.id` that it sent, and since the bytes are not equal, it throws a `wrong request ID` error.

In the example above:

`request.id = Uint8Array [0, 0, 0, 0, 0, 1]`
`bytesToBigint(request.id) = 1n`
`response.id = bigintToBytes(1n) = Uint8Array [1]`

----

This fix proposed here: 

- Changes the type of `RequestId` to `Uint8Array`
- Removes the `bytes<>bigint` conversions from `encode` and `decode`.  
- `createRequestId` now returns a `Uint8Array`.  
- Changes the comparisons of request.id to response.id to `equalsBytes` instead of `===` and `!==`.  
- Still use the `bigint` conversion as request map keys since Uint8Array cannot be a map key