### PR TITLE
fix: allow dual stack to use the same port

### DIFF
--- a/packages/discv5/src/transport/udp.ts
+++ b/packages/discv5/src/transport/udp.ts
@@ -78,11 +78,6 @@ export class UDPTransportService
       this.bindAddrs.push(this.ip6.addr);
       this.ipMode.ip6 = true;
     }
-    if (this.ip4 && this.ip6) {
-      if (this.ip4.opts.port === this.ip6.opts.port) {
-        throw new Error("Configured bind multiaddrs must have different ports");
-      }
-    }
   }
 
   public async start(): Promise<void> {

--- a/packages/discv5/test/unit/transport/udp.test.ts
+++ b/packages/discv5/test/unit/transport/udp.test.ts
@@ -106,13 +106,13 @@ describe("UDP4+6 transport", () => {
   const nodeIdA = bytesToHex(new Uint8Array(32).fill(1));
   const portA = 49523;
   const multiaddr4A = multiaddr(`/ip4/${address4}/udp/${portA}`);
-  const multiaddr6A = multiaddr(`/ip6/${address6}/udp/${portA + 1}`);
+  const multiaddr6A = multiaddr(`/ip6/${address6}/udp/${portA}`);
   const a = new UDPTransportService({ bindAddrs: { ip4: multiaddr4A, ip6: multiaddr6A }, nodeId: nodeIdA });
 
   const nodeIdB = bytesToHex(new Uint8Array(32).fill(2));
   const portB = portA + 1;
   const multiaddr4B = multiaddr(`/ip4/${address4}/udp/${portB}`);
-  const multiaddr6B = multiaddr(`/ip6/${address6}/udp/${portB + 1}`);
+  const multiaddr6B = multiaddr(`/ip6/${address6}/udp/${portB}`);
   const b = new UDPTransportService({ bindAddrs: { ip4: multiaddr4B, ip6: multiaddr6B }, nodeId: nodeIdB });
 
   before(async () => {


### PR DESCRIPTION
- Remove the faulty error condition "bind multiaddrs must have different ports"
- Allow ip4 and ip6 to use the same port