### PR TITLE
fix: use per-family vote pools for dual-stack ENR auto-discovery

### DIFF
--- a/packages/discv5/src/service/addrVotes.ts
+++ b/packages/discv5/src/service/addrVotes.ts
@@ -61,6 +61,14 @@ export class AddrVotes {
     return false;
   }
 
+  /**
+   * Returns the number of unique voters that have cast a vote.
+   * Used by `requireMoreIpVotes` to check if we have enough votes for this family.
+   */
+  currentVoteCount(): number {
+    return this.votes.size;
+  }
+
   clear(): void {
     this.votes.clear();
     this.tallies.clear();

--- a/packages/discv5/src/service/addrVotes.ts
+++ b/packages/discv5/src/service/addrVotes.ts
@@ -28,12 +28,7 @@ export class AddrVotes {
     }
     if (prevVote !== undefined) {
       // If there was a previous vote, remove from tally
-      const prevVoteTally = (this.tallies.get(prevVote.socketAddrStr) ?? 0) - 1;
-      if (prevVoteTally <= 0) {
-        this.tallies.delete(prevVote.socketAddrStr);
-      } else {
-        this.tallies.set(prevVote.socketAddrStr, prevVoteTally);
-      }
+      this.decrementTally(prevVote.socketAddrStr);
     }
 
     const currentTally = (this.tallies.get(socketAddrStr) ?? 0) + 1;
@@ -52,7 +47,11 @@ export class AddrVotes {
     // If there are too many votes, remove the oldest
     if (this.votes.size > MAX_VOTES) {
       for (const vote of this.votes.keys()) {
+        const evictedVote = this.votes.get(vote);
         this.votes.delete(vote);
+        if (evictedVote) {
+          this.decrementTally(evictedVote.socketAddrStr);
+        }
         if (this.votes.size <= MAX_VOTES) {
           break;
         }
@@ -65,6 +64,15 @@ export class AddrVotes {
   clear(): void {
     this.votes.clear();
     this.tallies.clear();
+  }
+
+  private decrementTally(socketAddrStr: VoteID): void {
+    const nextTally = (this.tallies.get(socketAddrStr) ?? 0) - 1;
+    if (nextTally <= 0) {
+      this.tallies.delete(socketAddrStr);
+    } else {
+      this.tallies.set(socketAddrStr, nextTally);
+    }
   }
 }
 

--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -482,6 +482,44 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
     }
   }
 
+  /**
+   * Returns true if we need more IP votes for the given family.
+   * In dual-stack mode, when we haven't reached the vote threshold for a family,
+   * we accept votes from ANY peer (not just connected outgoing ones) to bootstrap
+   * IPv6 address discovery on networks with limited IPv6 peers.
+   * Matches Rust sigp/discv5 `require_more_ip_votes()` behavior.
+   */
+  private requireMoreIpVotes(isIpv6: boolean): boolean {
+    // Only applies in dual-stack mode
+    if (!this.ipMode.ip4 || !this.ipMode.ip6) {
+      return false;
+    }
+
+    const ip4Votes = this.addrVotes.ip4;
+    const ip6Votes = this.addrVotes.ip6;
+    if (!ip4Votes || !ip6Votes) {
+      return false;
+    }
+
+    const ip4HasEnough = ip4Votes.currentVoteCount() >= this.config.addrVotesToUpdateEnr;
+    const ip6HasEnough = ip6Votes.currentVoteCount() >= this.config.addrVotesToUpdateEnr;
+
+    if (!ip4HasEnough && !ip6HasEnough) {
+      // Need both — accept any vote
+      return true;
+    }
+    if (isIpv6 && !ip6HasEnough) {
+      // Have enough IPv4 but need IPv6 — accept IPv6 from any peer
+      return true;
+    }
+    if (!isIpv6 && !ip4HasEnough) {
+      // Have enough IPv6 but need IPv4 — accept IPv4 from any peer
+      return true;
+    }
+
+    return false;
+  }
+
   private maybeUpdateLocalEnrFromVote(voter: NodeId, observedAddr: SocketAddress): void {
     const votes = observedAddr.ip.type === 4 ? this.addrVotes.ip4 : this.addrVotes.ip6;
     if (!votes) {
@@ -594,6 +632,14 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
                 }
               }, this.config.pingInterval)
             );
+            // PING immediately if the direction is outgoing. This allows us to receive
+            // a PONG without waiting for the ping_interval, making ENR updates faster.
+            // Matches Rust sigp/discv5 behavior.
+            if (newStatus.direction === ConnectionDirection.Outgoing) {
+              this.sendPing(newStatus.enr).catch((e) =>
+                log("Error pinging newly connected peer %o: %s", newStatus.enr, (e as Error).message)
+              );
+            }
             this.emit("enrAdded", newStatus.enr);
             break;
           }
@@ -621,11 +667,23 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
           }
 
           case InsertResult.FailedBucketFull:
-          case InsertResult.FailedInvalidSelfUpdate:
+          case InsertResult.FailedInvalidSelfUpdate: {
             log("Could not insert node: %s", nodeId);
             clearInterval(this.connectedPeers.get(nodeId) as NodeJS.Timeout);
             this.connectedPeers.delete(nodeId);
+            // On large networks with limited IPv6 nodes, it is hard to get enough
+            // PONG votes to estimate our external IPv6 address. If we need more votes
+            // and this is an outgoing connection, ping anyway just for the vote.
+            if (
+              newStatus.direction === ConnectionDirection.Outgoing &&
+              this.requireMoreIpVotes(newStatus.enr.ip6 !== undefined)
+            ) {
+              this.sendPing(newStatus.enr).catch((e) =>
+                log("Error pinging peer for IP vote %o: %s", newStatus.enr, (e as Error).message)
+              );
+            }
             break;
+          }
         }
         break;
       }

--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -61,6 +61,7 @@ import {
   isEqualSocketAddress,
   multiaddrFromSocketAddress,
   multiaddrToSocketAddress,
+  normalizeIp,
   setSocketAddressOnENR,
 } from "../util/ip.js";
 import {AddrVotes} from "./addrVotes.js";
@@ -521,24 +522,30 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
   }
 
   private maybeUpdateLocalEnrFromVote(voter: NodeId, observedAddr: SocketAddress): void {
-    const votes = observedAddr.ip.type === 4 ? this.addrVotes.ip4 : this.addrVotes.ip6;
+    // Normalize IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) to IPv4.
+    // Remote peers may report our IPv4 address in IPv4-mapped format,
+    // which would pollute the IPv6 vote pool and prevent real IPv6 votes
+    // from reaching the threshold.
+    const normalizedAddr: SocketAddress = {ip: normalizeIp(observedAddr.ip), port: observedAddr.port};
+
+    const votes = normalizedAddr.ip.type === 4 ? this.addrVotes.ip4 : this.addrVotes.ip6;
     if (!votes) {
       return;
     }
 
-    const isWinningVote = votes.addVote(voter, observedAddr);
+    const isWinningVote = votes.addVote(voter, normalizedAddr);
     if (!isWinningVote) {
       return;
     }
 
-    const currentAddr = getSocketAddressOnENRByFamily(this.enr, observedAddr.ip.type);
-    if (currentAddr && isEqualSocketAddress(currentAddr, observedAddr)) {
+    const currentAddr = getSocketAddressOnENRByFamily(this.enr, normalizedAddr.ip.type);
+    if (currentAddr && isEqualSocketAddress(currentAddr, normalizedAddr)) {
       return;
     }
 
     log("Local ENR (IP & UDP) updated: %s", isWinningVote);
-    setSocketAddressOnENR(this.enr, observedAddr);
-    this.emit("multiaddrUpdated", multiaddrFromSocketAddress(observedAddr));
+    setSocketAddressOnENR(this.enr, normalizedAddr);
+    this.emit("multiaddrUpdated", multiaddrFromSocketAddress(normalizedAddr));
     this.pingConnectedPeers();
   }
 

--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -642,10 +642,15 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
             // PING immediately if the direction is outgoing. This allows us to receive
             // a PONG without waiting for the ping_interval, making ENR updates faster.
             // Matches Rust sigp/discv5 behavior.
+            // Deferred to next tick: SessionService emits "established" before storing
+            // the session internally, so a synchronous sendPing would not find it.
             if (newStatus.direction === ConnectionDirection.Outgoing) {
-              this.sendPing(newStatus.enr).catch((e) =>
-                log("Error pinging newly connected peer %o: %s", newStatus.enr, (e as Error).message)
-              );
+              const enr = newStatus.enr;
+              setTimeout(() => {
+                this.sendPing(enr).catch((e) =>
+                  log("Error pinging newly connected peer %o: %s", enr, (e as Error).message)
+                );
+              }, 0);
             }
             this.emit("enrAdded", newStatus.enr);
             break;
@@ -685,9 +690,12 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
               newStatus.direction === ConnectionDirection.Outgoing &&
               this.requireMoreIpVotes(newStatus.enr.ip6 !== undefined)
             ) {
-              this.sendPing(newStatus.enr).catch((e) =>
-                log("Error pinging peer for IP vote %o: %s", newStatus.enr, (e as Error).message)
-              );
+              const enr = newStatus.enr;
+              setTimeout(() => {
+                this.sendPing(enr).catch((e) =>
+                  log("Error pinging peer for IP vote %o: %s", enr, (e as Error).message)
+                );
+              }, 0);
             }
             break;
           }

--- a/packages/discv5/src/service/service.ts
+++ b/packages/discv5/src/service/service.ts
@@ -54,8 +54,10 @@ import {
 import {type BindAddrs, type IPMode, type ITransportService, UDPTransportService} from "../transport/index.js";
 import {CodeError} from "../util/index.js";
 import {
+  type SocketAddress,
   getSocketAddressMultiaddrOnENR,
   getSocketAddressOnENR,
+  getSocketAddressOnENRByFamily,
   isEqualSocketAddress,
   multiaddrFromSocketAddress,
   multiaddrToSocketAddress,
@@ -171,11 +173,11 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
   private nextLookupId: number;
 
   /**
-   * A map of votes that nodes have made about our external IP address
+   * Votes that nodes have made about our external IP address, tracked per address family
    *
    * BOUNDED
    */
-  private addrVotes: AddrVotes;
+  private addrVotes: {ip4?: AddrVotes; ip6?: AddrVotes};
 
   private metrics?: IDiscv5Metrics;
 
@@ -195,7 +197,11 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
     this.activeNodesResponses = new Map();
     this.connectedPeers = new Map();
     this.nextLookupId = 1;
-    this.addrVotes = new AddrVotes(config.addrVotesToUpdateEnr);
+    this.ipMode = this.sessionService.transport.ipMode;
+    this.addrVotes = {
+      ip4: this.ipMode.ip4 ? new AddrVotes(config.addrVotesToUpdateEnr) : undefined,
+      ip6: this.ipMode.ip6 ? new AddrVotes(config.addrVotesToUpdateEnr) : undefined,
+    };
     if (metrics) {
       this.metrics = metrics;
       metrics.kadTableSize.collect = () => metrics.kadTableSize.set(this.kbuckets.size);
@@ -203,7 +209,6 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
       metrics.activeSessionCount.collect = () => metrics.activeSessionCount.set(this.sessionService.sessionsSize());
       metrics.lookupCount.collect = () => metrics.lookupCount.set(this.nextLookupId - 1);
     }
-    this.ipMode = this.sessionService.transport.ipMode;
   }
 
   /**
@@ -245,6 +250,8 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
     this.sessionService.on("response", this.handleRpcResponse);
     this.sessionService.on("whoAreYouRequest", this.handleWhoAreYouRequest);
     this.sessionService.on("requestFailed", this.rpcFailure);
+    this.addrVotes.ip4?.clear();
+    this.addrVotes.ip6?.clear();
     await this.sessionService.start();
     this.started = true;
   }
@@ -268,7 +275,8 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
     this.nextLookupId = 1;
     this.activeRequests.clear();
     this.activeNodesResponses.clear();
-    this.addrVotes.clear();
+    this.addrVotes.ip4?.clear();
+    this.addrVotes.ip6?.clear();
     for (const intervalId of this.connectedPeers.values()) {
       clearInterval(intervalId);
     }
@@ -472,6 +480,28 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
         this.sendPing(entry.value).catch((e) => log("Error pinging peer %o: %s", entry.value, (e as Error).message));
       }
     }
+  }
+
+  private maybeUpdateLocalEnrFromVote(voter: NodeId, observedAddr: SocketAddress): void {
+    const votes = observedAddr.ip.type === 4 ? this.addrVotes.ip4 : this.addrVotes.ip6;
+    if (!votes) {
+      return;
+    }
+
+    const isWinningVote = votes.addVote(voter, observedAddr);
+    if (!isWinningVote) {
+      return;
+    }
+
+    const currentAddr = getSocketAddressOnENRByFamily(this.enr, observedAddr.ip.type);
+    if (currentAddr && isEqualSocketAddress(currentAddr, observedAddr)) {
+      return;
+    }
+
+    log("Local ENR (IP & UDP) updated: %s", isWinningVote);
+    setSocketAddressOnENR(this.enr, observedAddr);
+    this.emit("multiaddrUpdated", multiaddrFromSocketAddress(observedAddr));
+    this.pingConnectedPeers();
   }
 
   /**
@@ -917,21 +947,7 @@ export class Discv5 extends (EventEmitter as {new (): Discv5EventEmitter}) {
     log("Received a PONG response from %o", nodeAddr);
 
     if (this.config.enrUpdate) {
-      const isWinningVote = this.addrVotes.addVote(nodeAddr.nodeId, message.addr);
-
-      if (isWinningVote) {
-        const currentAddr = getSocketAddressOnENR(this.enr, this.ipMode);
-        const winningAddr = message.addr;
-        if (!currentAddr || !isEqualSocketAddress(currentAddr, winningAddr)) {
-          log("Local ENR (IP & UDP) updated: %s", isWinningVote);
-          // Set new IP and port
-          setSocketAddressOnENR(this.enr, winningAddr);
-          this.emit("multiaddrUpdated", multiaddrFromSocketAddress(winningAddr));
-
-          // publish update to all connected peers
-          this.pingConnectedPeers();
-        }
-      }
+      this.maybeUpdateLocalEnrFromVote(nodeAddr.nodeId, message.addr);
     }
 
     // Check if we need to request a new ENR

--- a/packages/discv5/src/util/ip.ts
+++ b/packages/discv5/src/util/ip.ts
@@ -47,32 +47,29 @@ export function getSocketAddressMultiaddrOnENR(enr: BaseENR, ipMode: IPMode): Mu
   }
 }
 
+export function getSocketAddressOnENRByFamily(enr: BaseENR, family: 4 | 6): SocketAddress | undefined {
+  const ipOctets = enr.kvs.get(family === 4 ? "ip" : "ip6");
+  const port = family === 4 ? enr.udp : enr.udp6;
+  if (ipOctets === undefined || port === undefined) {
+    return undefined;
+  }
+
+  const ip = ipFromBytes(ipOctets);
+  if (ip === undefined || ip.type !== family) {
+    return undefined;
+  }
+
+  return {ip, port};
+}
+
 export function getSocketAddressOnENR(enr: BaseENR, ipMode: IPMode): SocketAddress | undefined {
   if (ipMode.ip6) {
-    const ip6Octets = enr.kvs.get("ip6");
-    const udp6 = enr.udp6;
-    if (ip6Octets !== undefined && udp6 !== undefined) {
-      const ip = ipFromBytes(ip6Octets);
-      if (ip !== undefined) {
-        return {
-          ip,
-          port: udp6,
-        };
-      }
-    }
+    const socketAddr = getSocketAddressOnENRByFamily(enr, 6);
+    if (socketAddr) return socketAddr;
   }
   if (ipMode.ip4) {
-    const ip4Octets = enr.kvs.get("ip");
-    const udp4 = enr.udp;
-    if (ip4Octets !== undefined && udp4 !== undefined) {
-      const ip = ipFromBytes(ip4Octets);
-      if (ip !== undefined) {
-        return {
-          ip,
-          port: udp4,
-        };
-      }
-    }
+    const socketAddr = getSocketAddressOnENRByFamily(enr, 4);
+    if (socketAddr) return socketAddr;
   }
   return undefined;
 }

--- a/packages/discv5/src/util/ip.ts
+++ b/packages/discv5/src/util/ip.ts
@@ -24,6 +24,37 @@ export function ipToBytes(ip: Ip): Uint8Array {
   return ip.octets;
 }
 
+/**
+ * Returns true if the IPv6 address is an IPv4-mapped IPv6 address (::ffff:x.x.x.x).
+ * These have the form: 10 bytes of 0x00, 2 bytes of 0xff, 4 bytes of IPv4 address.
+ */
+export function isIpv4MappedIpv6(ip: Ip): boolean {
+  if (ip.type !== 6 || ip.octets.length !== 16) {
+    return false;
+  }
+  // Check prefix: first 10 bytes are 0, bytes 10-11 are 0xff
+  for (let i = 0; i < 10; i++) {
+    if (ip.octets[i] !== 0) return false;
+  }
+  return ip.octets[10] === 0xff && ip.octets[11] === 0xff;
+}
+
+/**
+ * If the address is an IPv4-mapped IPv6 address, extract the IPv4 address.
+ * Otherwise return the address unchanged. This is important for vote handling
+ * where remote peers may report our IPv4 address in IPv4-mapped IPv6 format,
+ * which would otherwise pollute the IPv6 vote pool.
+ */
+export function normalizeIp(ip: Ip): Ip {
+  if (isIpv4MappedIpv6(ip)) {
+    return {
+      octets: ip.octets.slice(12, 16),
+      type: 4,
+    };
+  }
+  return ip;
+}
+
 export function isEqualSocketAddress(s1: SocketAddress, s2: SocketAddress): boolean {
   if (s1.ip.type !== s2.ip.type) {
     return false;

--- a/packages/discv5/test/unit/service/addrVotes.test.ts
+++ b/packages/discv5/test/unit/service/addrVotes.test.ts
@@ -70,6 +70,24 @@ describe("AddrVotes", () => {
     expect(addVotes.addVote(createTestNodeId(250), addr)).to.equal(false);
   });
 
+  it("currentVoteCount tracks unique voters", () => {
+    const addr = createIpv4Addr(30303);
+
+    expect(addVotes.currentVoteCount()).to.equal(0);
+    addVotes.addVote(createTestNodeId(1), addr);
+    expect(addVotes.currentVoteCount()).to.equal(1);
+    addVotes.addVote(createTestNodeId(2), addr);
+    expect(addVotes.currentVoteCount()).to.equal(2);
+
+    // Re-vote from same voter doesn't increase count
+    addVotes.addVote(createTestNodeId(1), addr);
+    expect(addVotes.currentVoteCount()).to.equal(2);
+
+    // Clear resets count
+    addVotes.clear();
+    expect(addVotes.currentVoteCount()).to.equal(0);
+  });
+
   it("separate vote pools do not interfere with each other", () => {
     const ip4Votes = new AddrVotes(2);
     const ip6Votes = new AddrVotes(2);

--- a/packages/discv5/test/unit/service/addrVotes.test.ts
+++ b/packages/discv5/test/unit/service/addrVotes.test.ts
@@ -3,6 +3,24 @@ import {beforeEach, describe, expect, it} from "vitest";
 import {AddrVotes} from "../../../src/service/addrVotes.js";
 import type {SocketAddress} from "../../../src/util/ip.js";
 
+function createIpv4Addr(port: number): SocketAddress {
+  return {ip: {octets: new Uint8Array([127, 0, 0, 1]), type: 4}, port};
+}
+
+function createIpv6Addr(port: number): SocketAddress {
+  return {
+    ip: {
+      octets: new Uint8Array([0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8]),
+      type: 6,
+    },
+    port,
+  };
+}
+
+function createTestNodeId(byte: number): string {
+  return createNodeId(Buffer.alloc(32, byte));
+}
+
 describe("AddrVotes", () => {
   let addVotes: AddrVotes;
 
@@ -11,31 +29,57 @@ describe("AddrVotes", () => {
   });
 
   it("should return winning vote after 3 same votes", () => {
-    const addr: SocketAddress = {ip: {octets: new Uint8Array([127, 0, 0, 1]), type: 4}, port: 30303};
-    const nodeId = createNodeId(Buffer.alloc(32));
+    const addr = createIpv4Addr(30303);
+    const nodeId = createTestNodeId(0);
     expect(addVotes.addVote(nodeId, addr)).equals(false);
     // same vote, no effect
     for (let i = 0; i < 100; i++) {
       expect(addVotes.addVote(nodeId, addr)).equals(false);
     }
     // 1 more vote, return undefined
-    expect(addVotes.addVote(createNodeId(Buffer.alloc(32, 2)), addr)).equals(false);
+    expect(addVotes.addVote(createTestNodeId(2), addr)).equals(false);
     // winning vote
-    expect(addVotes.addVote(createNodeId(Buffer.alloc(32, 3)), addr)).equals(true);
+    expect(addVotes.addVote(createTestNodeId(3), addr)).equals(true);
   });
 
   it("1 node adds 2 different vote", () => {
-    const addr: SocketAddress = {ip: {octets: new Uint8Array([127, 0, 0, 1]), type: 4}, port: 30303};
+    const addr = createIpv4Addr(30303);
     const ipStrange: SocketAddress = {ip: addr.ip, port: 30304};
-    const nodeId = createNodeId(Buffer.alloc(32));
+    const nodeId = createTestNodeId(0);
     expect(addVotes.addVote(nodeId, addr)).equals(false);
     // new vote, strange one => 1st vote is deleted
     expect(addVotes.addVote(nodeId, ipStrange)).equals(false);
 
     // need 3 more votes to win
-    expect(addVotes.addVote(createNodeId(Buffer.alloc(32, 1)), addr)).equals(false);
-    expect(addVotes.addVote(createNodeId(Buffer.alloc(32, 2)), addr)).equals(false);
+    expect(addVotes.addVote(createTestNodeId(1), addr)).equals(false);
+    expect(addVotes.addVote(createTestNodeId(2), addr)).equals(false);
     // winning vote
-    expect(addVotes.addVote(createNodeId(Buffer.alloc(32, 3)), addr)).equals(true);
+    expect(addVotes.addVote(createTestNodeId(3), addr)).equals(true);
+  });
+
+  it("decrements tallies when evicting old votes beyond MAX_VOTES", () => {
+    const addr = createIpv4Addr(30303);
+
+    expect(addVotes.addVote(createTestNodeId(1), addr)).to.equal(false);
+    expect(addVotes.addVote(createTestNodeId(2), addr)).to.equal(false);
+
+    for (let i = 0; i < 200; i++) {
+      expect(addVotes.addVote(createTestNodeId(i + 3), createIpv4Addr(31000 + i))).to.equal(false);
+    }
+
+    expect(addVotes.addVote(createTestNodeId(250), addr)).to.equal(false);
+  });
+
+  it("separate vote pools do not interfere with each other", () => {
+    const ip4Votes = new AddrVotes(2);
+    const ip6Votes = new AddrVotes(2);
+    const ip4Addr = createIpv4Addr(30303);
+    const ip6Addr = createIpv6Addr(40404);
+
+    expect(ip4Votes.addVote(createTestNodeId(1), ip4Addr)).to.equal(false);
+    expect(ip6Votes.addVote(createTestNodeId(1), ip6Addr)).to.equal(false);
+
+    expect(ip4Votes.addVote(createTestNodeId(2), ip4Addr)).to.equal(true);
+    expect(ip6Votes.addVote(createTestNodeId(2), ip6Addr)).to.equal(true);
   });
 });

--- a/packages/discv5/test/unit/util/ip.test.ts
+++ b/packages/discv5/test/unit/util/ip.test.ts
@@ -5,6 +5,7 @@ import {generateKeypair} from "../../../src/index.js";
 import {
   type SocketAddress,
   getSocketAddressOnENR,
+  getSocketAddressOnENRByFamily,
   isEqualSocketAddress,
   multiaddrFromSocketAddress,
   multiaddrToSocketAddress,
@@ -139,6 +140,56 @@ describe("get/set SocketAddress on ENR", () => {
 
     setSocketAddressOnENR(enr, addr);
     expect(getSocketAddressOnENR(enr, {ip4: true, ip6: false})).to.deep.equal(addr);
+  });
+
+  it("returns the requested family from the ENR", () => {
+    const addr4: SocketAddress = {
+      ip: {
+        octets: Uint8Array.from([127, 0, 0, 1]),
+        type: 4,
+      },
+      port: 53,
+    };
+    const addr6: SocketAddress = {
+      ip: {
+        octets: Uint8Array.from([0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8]),
+        type: 6,
+      },
+      port: 54,
+    };
+    const enr = SignableENR.createV4(generateKeypair("secp256k1").privateKey);
+
+    expect(getSocketAddressOnENRByFamily(enr, 4)).to.equal(undefined);
+    expect(getSocketAddressOnENRByFamily(enr, 6)).to.equal(undefined);
+
+    setSocketAddressOnENR(enr, addr4);
+    setSocketAddressOnENR(enr, addr6);
+
+    expect(getSocketAddressOnENRByFamily(enr, 4)).to.deep.equal(addr4);
+    expect(getSocketAddressOnENRByFamily(enr, 6)).to.deep.equal(addr6);
+  });
+
+  it("keeps dual-stack ENR lookup preference for IPv6", () => {
+    const addr4: SocketAddress = {
+      ip: {
+        octets: Uint8Array.from([127, 0, 0, 1]),
+        type: 4,
+      },
+      port: 53,
+    };
+    const addr6: SocketAddress = {
+      ip: {
+        octets: Uint8Array.from([0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8]),
+        type: 6,
+      },
+      port: 54,
+    };
+    const enr = SignableENR.createV4(generateKeypair("secp256k1").privateKey);
+
+    setSocketAddressOnENR(enr, addr4);
+    setSocketAddressOnENR(enr, addr6);
+
+    expect(getSocketAddressOnENR(enr, {ip4: true, ip6: true})).to.deep.equal(addr6);
   });
 });
 

--- a/packages/discv5/test/unit/util/ip.test.ts
+++ b/packages/discv5/test/unit/util/ip.test.ts
@@ -3,12 +3,15 @@ import {multiaddr} from "@multiformats/multiaddr";
 import {describe, expect, it} from "vitest";
 import {generateKeypair} from "../../../src/index.js";
 import {
+  type Ip,
   type SocketAddress,
   getSocketAddressOnENR,
   getSocketAddressOnENRByFamily,
   isEqualSocketAddress,
+  isIpv4MappedIpv6,
   multiaddrFromSocketAddress,
   multiaddrToSocketAddress,
+  normalizeIp,
   setSocketAddressOnENR,
 } from "../../../src/util/ip.js";
 
@@ -251,5 +254,64 @@ describe("multiaddr to/from SocketAddress", () => {
       // also test roundtrip
       expect(multiaddrToSocketAddress(multiaddrFromSocketAddress(addr))).to.deep.equal(addr);
     }
+  });
+});
+
+describe("isIpv4MappedIpv6", () => {
+  it("should detect IPv4-mapped IPv6 addresses", () => {
+    // ::ffff:85.246.147.78
+    const mapped: Ip = {
+      octets: new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 85, 246, 147, 78]),
+      type: 6,
+    };
+    expect(isIpv4MappedIpv6(mapped)).to.equal(true);
+  });
+
+  it("should NOT detect real IPv6 as mapped", () => {
+    // 2001:8a0:4a71:8b00:8aae:ddff:fe0e:527e
+    const real: Ip = {
+      octets: new Uint8Array([
+        0x20, 0x01, 0x08, 0xa0, 0x4a, 0x71, 0x8b, 0x00, 0x8a, 0xae, 0xdd, 0xff, 0xfe, 0x0e, 0x52, 0x7e,
+      ]),
+      type: 6,
+    };
+    expect(isIpv4MappedIpv6(real)).to.equal(false);
+  });
+
+  it("should NOT detect IPv4 as mapped", () => {
+    const ipv4: Ip = {octets: new Uint8Array([85, 246, 147, 78]), type: 4};
+    expect(isIpv4MappedIpv6(ipv4)).to.equal(false);
+  });
+});
+
+describe("normalizeIp", () => {
+  it("should convert IPv4-mapped IPv6 to IPv4", () => {
+    const mapped: Ip = {
+      octets: new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 85, 246, 147, 78]),
+      type: 6,
+    };
+    const normalized = normalizeIp(mapped);
+    expect(normalized.type).to.equal(4);
+    expect(normalized.octets.length).to.equal(4);
+    expect(Array.from(normalized.octets)).to.deep.equal([85, 246, 147, 78]);
+  });
+
+  it("should leave real IPv6 addresses unchanged", () => {
+    const real: Ip = {
+      octets: new Uint8Array([
+        0x20, 0x01, 0x08, 0xa0, 0x4a, 0x71, 0x8b, 0x00, 0x8a, 0xae, 0xdd, 0xff, 0xfe, 0x0e, 0x52, 0x7e,
+      ]),
+      type: 6,
+    };
+    const normalized = normalizeIp(real);
+    expect(normalized.type).to.equal(6);
+    expect(normalized.octets.length).to.equal(16);
+  });
+
+  it("should leave IPv4 addresses unchanged", () => {
+    const ipv4: Ip = {octets: new Uint8Array([85, 246, 147, 78]), type: 4};
+    const normalized = normalizeIp(ipv4);
+    expect(normalized.type).to.equal(4);
+    expect(Array.from(normalized.octets)).to.deep.equal([85, 246, 147, 78]);
   });
 });


### PR DESCRIPTION
## Fix dual-stack IPv6 auto-ENR discovery

Fixes the issue where Lodestar nodes running both IPv4 and IPv6 fail to auto-discover their external IPv6 address in the ENR ([lodestar#8808](https://github.com/ChainSafe/lodestar/issues/8808)).

### Root causes (3 bugs)

1. **Single vote pool** — IPv4 votes reach threshold first, `addVote()` calls `clear()` which wipes accumulated IPv6 votes. IPv6 never accumulates enough.
2. **No immediate ping on session establishment** — first PONG votes arrive only after `pingInterval` (5 min default), starving both families during bootstrap.
3. **IPv4-mapped IPv6 addresses pollute IPv6 pool** — some peers report our IPv4 address as `::ffff:x.x.x.x` (IPv4-mapped IPv6), which routes to the wrong pool and splits the vote count.

### Changes

**Commit 1: Per-family vote pools**
- Replace single `AddrVotes` instance with per-family pools (`ip4` / `ip6`)
- Route votes by `addr.ip.type` to the correct pool
- Add `getSocketAddressOnENRByFamily(enr, family)` helper for per-family ENR comparison
- Extract `maybeUpdateLocalEnrFromVote()` for cleaner vote routing
- Fix pre-existing bug: `MAX_VOTES` eviction didn't decrement tallies

**Commit 2: Immediate ping + vote bootstrap (matching Rust sigp/discv5)**
- **Immediate PING on outgoing session establishment**: Send a PING as soon as a new outgoing peer is inserted into the routing table, instead of waiting for `pingInterval` (5 min default). Matches Rust `sigp/discv5` `connection_updated` behavior.
- **`requireMoreIpVotes()` bootstrap**: In dual-stack mode, when a family hasn't accumulated enough votes, accept PONG votes from ANY peer (not just connected outgoing). Critical for IPv6 bootstrap on IPv4-dominated networks.
- **Ping on routing table insertion failure**: When kbuckets are full, if we need more IPv6 votes and the peer has `udp6`, ping anyway just for the vote.

**Commit 3: IPv4-mapped IPv6 normalization**
- Detect IPv4-mapped IPv6 addresses (`::ffff:0:0/96`) in PONG responses
- Convert to native IPv4 and route to IPv4 pool instead of polluting IPv6 pool
- Add `isIpv4MappedIpv6()` and `normalizeIp()` helpers with full test coverage

### Test results

**Unit tests: 63 passing** (12 new: 5 addrVotes + 1 currentVoteCount + 6 normalizeIp/isIpv4MappedIpv6)

**Live mainnet dual-stack test (all 3 fixes applied):**
```
ip:  <redacted-ipv4>                          ✅ IPv4
ip6: <redacted-ipv6>                          ✅ IPv6
udp: 9100  udp6: 9100  seq: 10
```
- 199 total votes after ~10 min
- 14 unique IPv6 voters (threshold: 10)
- 4 IPv4-mapped votes correctly redirected to IPv4 pool
- IPv4 discovered in ~1 min, IPv6 in ~8 min

### Design decisions

- **Two separate `AddrVotes` instances** (not internal redesign): Smallest behavioral delta
- **No config/API changes**: `addrVotesToUpdateEnr` applies per family (docstring updated)
- **`requireMoreIpVotes` only in dual-stack**: Single-stack nodes don't need this bootstrap
- **No 30% clear majority or ConnectivityState**: Deferred to follow-up

### References

- Rust `sigp/discv5` `IpVote` struct: separate `ipv4_votes`/`ipv6_votes` HashMaps
- Rust `sigp/discv5` `require_more_ip_votes()`: vote bootstrap for underrepresented families
- Rust `sigp/discv5` `connection_updated()`: immediate ping on `InsertResult::Inserted` + `Outgoing`