### PR TITLE
fix(enr): handle short port values without throwing

### DIFF
--- a/packages/discv5/test/unit/util/ip.test.ts
+++ b/packages/discv5/test/unit/util/ip.test.ts
@@ -145,6 +145,27 @@ describe("get/set SocketAddress on ENR", () => {
     expect(getSocketAddressOnENR(enr, {ip4: true, ip6: false})).to.deep.equal(addr);
   });
 
+  it("accepts a one-byte UDP port from a remote ENR", () => {
+    const enr = SignableENR.createV4(generateKeypair("secp256k1").privateKey);
+    enr.set("ip", Uint8Array.from([127, 0, 0, 1]));
+    enr.set("udp", Uint8Array.from([53]));
+
+    expect(getSocketAddressOnENR(enr, {ip4: true, ip6: false})).to.deep.equal({
+      ip: {octets: Uint8Array.from([127, 0, 0, 1]), type: 4},
+      port: 53,
+    });
+  });
+
+  it("ignores an invalid UDP port from a remote ENR", () => {
+    const enr = SignableENR.createV4(generateKeypair("secp256k1").privateKey);
+    enr.set("ip", Uint8Array.from([127, 0, 0, 1]));
+
+    for (const port of [new Uint8Array(), Uint8Array.from([0]), Uint8Array.from([1, 2, 3])]) {
+      enr.set("udp", port);
+      expect(getSocketAddressOnENR(enr, {ip4: true, ip6: false})).to.be.undefined;
+    }
+  });
+
   it("returns the requested family from the ENR", () => {
     const addr4: SocketAddress = {
       ip: {

--- a/packages/enr/src/enr.ts
+++ b/packages/enr/src/enr.ts
@@ -181,18 +181,10 @@ export function getIPValue(
 }
 
 export function getProtocolValue(kvs: ReadonlyMap<ENRKey, ENRValue>, key: string): number | undefined {
-  const raw = normalizePortBytes(kvs.get(key));
-  if (raw) {
-    return (raw[0] << 8) + raw[1];
-  }
-  return undefined;
-}
-
-function normalizePortBytes(raw: Uint8Array | undefined): Uint8Array | undefined {
+  const raw = kvs.get(key);
   if (!raw || raw.length === 0 || raw.length > 2) return undefined;
-  if (raw.length === 1) return raw[0] === 0 ? undefined : new Uint8Array([0, raw[0]]);
-  if (raw[0] === 0 && raw[1] === 0) return undefined;
-  return raw;
+  const port = raw.length === 1 ? raw[0] : (raw[0] << 8) + raw[1];
+  return port === 0 ? undefined : port;
 }
 
 export function portToBuf(port: number): Uint8Array {
@@ -341,38 +333,38 @@ export abstract class BaseENR {
     };
 
     if (isUdp) {
-      const protoVal = normalizePortBytes(isIpv6 ? this.kvs.get("udp6") : this.kvs.get("udp"));
-      if (!protoVal) {
+      const port = getProtocolValue(this.kvs, isIpv6 ? "udp6" : "udp");
+      if (port === undefined) {
         return undefined;
       }
       const protoComponent: Component = {
         code: udp.code,
         name: udp.name,
-        value: udp.bytesToValue?.(toNewUint8Array(protoVal)),
+        value: port.toString(),
       };
       return multiaddr([ipComponent, protoComponent]);
     }
     if (isTcp) {
-      const protoVal = normalizePortBytes(isIpv6 ? this.kvs.get("tcp6") : this.kvs.get("tcp"));
-      if (!protoVal) {
+      const port = getProtocolValue(this.kvs, isIpv6 ? "tcp6" : "tcp");
+      if (port === undefined) {
         return undefined;
       }
       const protoComponent: Component = {
         code: tcp.code,
         name: tcp.name,
-        value: tcp.bytesToValue?.(toNewUint8Array(protoVal)),
+        value: port.toString(),
       };
       return multiaddr([ipComponent, protoComponent]);
     }
     if (isQuic) {
-      const protoVal = normalizePortBytes(isIpv6 ? this.kvs.get("quic6") : this.kvs.get("quic"));
-      if (!protoVal) {
+      const port = getProtocolValue(this.kvs, isIpv6 ? "quic6" : "quic");
+      if (port === undefined) {
         return undefined;
       }
       const protoComponent: Component = {
         code: udp.code,
         name: udp.name,
-        value: udp.bytesToValue?.(toNewUint8Array(protoVal)),
+        value: port.toString(),
       };
       return multiaddr([ipComponent, protoComponent]).encapsulate("/quic-v1");
     }

--- a/packages/enr/src/enr.ts
+++ b/packages/enr/src/enr.ts
@@ -180,12 +180,15 @@ export function getIPValue(
   return undefined;
 }
 
-export function getProtocolValue(kvs: ReadonlyMap<ENRKey, ENRValue>, key: string): number | undefined {
+export function getPortValue(kvs: ReadonlyMap<ENRKey, ENRValue>, key: string): number | undefined {
   const raw = kvs.get(key);
   if (!raw || raw.length === 0 || raw.length > 2) return undefined;
   const port = raw.length === 1 ? raw[0] : (raw[0] << 8) + raw[1];
   return port === 0 ? undefined : port;
 }
+
+/** @deprecated Use {@link getPortValue} instead. */
+export const getProtocolValue = getPortValue;
 
 export function portToBuf(port: number): Uint8Array {
   const buf = new Uint8Array(2);
@@ -284,25 +287,25 @@ export abstract class BaseENR {
     return getIPValue(this.kvs, "ip", "ip4");
   }
   get tcp(): number | undefined {
-    return getProtocolValue(this.kvs, "tcp");
+    return getPortValue(this.kvs, "tcp");
   }
   get udp(): number | undefined {
-    return getProtocolValue(this.kvs, "udp");
+    return getPortValue(this.kvs, "udp");
   }
   get quic(): number | undefined {
-    return getProtocolValue(this.kvs, "quic");
+    return getPortValue(this.kvs, "quic");
   }
   get ip6(): string | undefined {
     return getIPValue(this.kvs, "ip6", "ip6");
   }
   get tcp6(): number | undefined {
-    return getProtocolValue(this.kvs, "tcp6");
+    return getPortValue(this.kvs, "tcp6");
   }
   get udp6(): number | undefined {
-    return getProtocolValue(this.kvs, "udp6");
+    return getPortValue(this.kvs, "udp6");
   }
   get quic6(): number | undefined {
-    return getProtocolValue(this.kvs, "quic6");
+    return getPortValue(this.kvs, "quic6");
   }
   getLocationMultiaddr(protocol: Protocol): Multiaddr | undefined {
     if (protocol === "udp") {
@@ -333,7 +336,7 @@ export abstract class BaseENR {
     };
 
     if (isUdp) {
-      const port = getProtocolValue(this.kvs, isIpv6 ? "udp6" : "udp");
+      const port = getPortValue(this.kvs, isIpv6 ? "udp6" : "udp");
       if (port === undefined) {
         return undefined;
       }
@@ -345,7 +348,7 @@ export abstract class BaseENR {
       return multiaddr([ipComponent, protoComponent]);
     }
     if (isTcp) {
-      const port = getProtocolValue(this.kvs, isIpv6 ? "tcp6" : "tcp");
+      const port = getPortValue(this.kvs, isIpv6 ? "tcp6" : "tcp");
       if (port === undefined) {
         return undefined;
       }
@@ -357,7 +360,7 @@ export abstract class BaseENR {
       return multiaddr([ipComponent, protoComponent]);
     }
     if (isQuic) {
-      const port = getProtocolValue(this.kvs, isIpv6 ? "quic6" : "quic");
+      const port = getPortValue(this.kvs, isIpv6 ? "quic6" : "quic");
       if (port === undefined) {
         return undefined;
       }
@@ -572,7 +575,7 @@ export class SignableENR extends BaseENR {
     }
   }
   get tcp(): number | undefined {
-    return getProtocolValue(this.kvs, "tcp");
+    return getPortValue(this.kvs, "tcp");
   }
   set tcp(port: number | undefined) {
     if (port === undefined) {
@@ -582,7 +585,7 @@ export class SignableENR extends BaseENR {
     }
   }
   get udp(): number | undefined {
-    return getProtocolValue(this.kvs, "udp");
+    return getPortValue(this.kvs, "udp");
   }
   set udp(port: number | undefined) {
     if (port === undefined) {
@@ -592,7 +595,7 @@ export class SignableENR extends BaseENR {
     }
   }
   get quic(): number | undefined {
-    return getProtocolValue(this.kvs, "quic");
+    return getPortValue(this.kvs, "quic");
   }
   set quic(port: number | undefined) {
     if (port === undefined) {
@@ -613,7 +616,7 @@ export class SignableENR extends BaseENR {
     }
   }
   get tcp6(): number | undefined {
-    return getProtocolValue(this.kvs, "tcp6");
+    return getPortValue(this.kvs, "tcp6");
   }
   set tcp6(port: number | undefined) {
     if (port === undefined) {
@@ -623,7 +626,7 @@ export class SignableENR extends BaseENR {
     }
   }
   get udp6(): number | undefined {
-    return getProtocolValue(this.kvs, "udp6");
+    return getPortValue(this.kvs, "udp6");
   }
   set udp6(port: number | undefined) {
     if (port === undefined) {
@@ -633,7 +636,7 @@ export class SignableENR extends BaseENR {
     }
   }
   get quic6(): number | undefined {
-    return getProtocolValue(this.kvs, "quic6");
+    return getPortValue(this.kvs, "quic6");
   }
   set quic6(port: number | undefined) {
     if (port === undefined) {

--- a/packages/enr/src/enr.ts
+++ b/packages/enr/src/enr.ts
@@ -181,11 +181,8 @@ export function getIPValue(
 }
 
 export function getProtocolValue(kvs: ReadonlyMap<ENRKey, ENRValue>, key: string): number | undefined {
-  const raw = kvs.get(key);
+  const raw = normalizePortBytes(kvs.get(key));
   if (raw) {
-    if (raw.length < 2) {
-      throw new Error("Encoded protocol length should be 2");
-    }
     return (raw[0] << 8) + raw[1];
   }
   return undefined;
@@ -193,8 +190,8 @@ export function getProtocolValue(kvs: ReadonlyMap<ENRKey, ENRValue>, key: string
 
 function normalizePortBytes(raw: Uint8Array | undefined): Uint8Array | undefined {
   if (!raw || raw.length === 0 || raw.length > 2) return undefined;
-  if (raw[0] === 0) return undefined;
-  if (raw.length === 1) return new Uint8Array([0, raw[0]]);
+  if (raw.length === 1) return raw[0] === 0 ? undefined : new Uint8Array([0, raw[0]]);
+  if (raw[0] === 0 && raw[1] === 0) return undefined;
   return raw;
 }
 

--- a/packages/enr/test/unit/enr.test.ts
+++ b/packages/enr/test/unit/enr.test.ts
@@ -70,6 +70,38 @@ describe("ENR multiaddr support", () => {
     record = SignableENR.createV4(privateKey);
   });
 
+  describe("port values", () => {
+    beforeEach(() => {
+      record.ip = "127.0.0.1";
+    });
+
+    it("should decode a one-byte port", () => {
+      record.set("udp", new Uint8Array([80]));
+
+      expect(record.udp).to.equal(80);
+      expect(record.getLocationMultiaddr("udp")?.toString()).to.equal("/ip4/127.0.0.1/udp/80");
+    });
+
+    it("should decode a two-byte low port", () => {
+      record.udp = 80;
+
+      expect(record.kvs.get("udp")).to.deep.equal(new Uint8Array([0, 80]));
+      expect(record.udp).to.equal(80);
+      expect(record.getLocationMultiaddr("udp")?.toString()).to.equal("/ip4/127.0.0.1/udp/80");
+    });
+
+    it("should ignore invalid port values", () => {
+      const invalidPorts = [new Uint8Array(), new Uint8Array([0]), new Uint8Array([0, 0]), new Uint8Array([1, 2, 3])];
+
+      for (const port of invalidPorts) {
+        record.set("udp", port);
+
+        expect(record.udp).to.be.undefined;
+        expect(record.getLocationMultiaddr("udp")).to.be.undefined;
+      }
+    });
+  });
+
   it("should get / set UDP multiaddr", () => {
     const multi0 = multiaddr("/ip4/127.0.0.1/udp/30303");
     const components0 = multi0.getComponents();


### PR DESCRIPTION
## What changed

- normalize ENR port bytes before `getProtocolValue()` reads them
- accept valid one-byte and two-byte big-endian port values
- return `undefined` for empty, zero, or oversized port values instead of throwing
- keep low ports produced by the existing setters usable by `getLocationMultiaddr()`
- add ENR-level regression tests and direct coverage for discv5's `getSocketAddressOnENR()` path

## Why

A mainnet Lodestar v1.45.0 node using `@chainsafe/enr@6.0.1` and `@chainsafe/discv5@12.0.1` received a signed remote ENR with a short `udp` value. During session establishment, `getSocketAddressOnENR()` accessed `enr.udp`, and `getProtocolValue()` threw:

```
uncaughtException: Encoded protocol length should be 2
at getProtocolValue
at get udp
at getSocketAddressOnENRByFamily
at getSocketAddressOnENR
at SessionService.onEstablished
```

ENR ports are big-endian integers, so one-byte values are valid. Invalid values received from untrusted peers should make the ENR non-contactable rather than escape as an exception.

This follows up on the normalization added in #333 and applies it to the direct port getters used by discv5.

Related: ChainSafe/lodestar#7445, ChainSafe/lodestar#9310.

## Impact

Valid compact ports now decode correctly. Empty, zero, and oversized values are ignored without disrupting the discv5 session service. Normal two-byte ports are unchanged.

## Validation

- `pnpm build`
- `pnpm lint` (passes; two existing warnings outside this change)
- `pnpm check-types`
- `pnpm test:unit` — 28 ENR tests and 65 discv5 tests pass
- `pnpm test:e2e` — 5 tests pass
